### PR TITLE
Feat/system settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## Unreleased
+
+- Feat: Enable the feature flag `system_settings` to override AndroidManifest.xml such that app is included in the Android System Settings home page, instead of the App Grid like a typical user app.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 #  mobile-conductor-admin
 
 An Android app for managing a holochain conductor running as a foreground service.
+
+## Build
+
+### Build as a Standalone User App
+
+By default, this will be built as a standard user app that only appears in the App Grid. 
+
+### Build as a System App
+
+To build as a system app that only appears in the Android System Settings page, use the feature flag `system_settings`.
+
+i.e. `npm run tauri build -- --features system_settings`

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,14 @@ crate-type = ["staticlib", "cdylib", "lib"]
 
 [build-dependencies]
 tauri-build = { version = "2.0.3", default-features = false , features = [] }
+tauri-plugin = "2.0.4"
 
 [dependencies]
 tauri = { version = "2.1.1", features = ["unstable"] }
 tauri-plugin-holochain-service = { git = "https://github.com/mattyg/p2p-shipyard.git", branch = "feat/foreground-service", package = "tauri-plugin-holochain-service" }
+
+[features]
+default = []
+
+# Should app be visible via the Android System Settings page, instead of the app grid?
+system_settings = []

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,46 @@
 fn main() {
-  tauri_build::build()
+  let res = tauri_build::build();
+
+  #[cfg(feature="system_settings")]
+  tauri_plugin::mobile::update_android_manifest(
+    "Include in App Grid or System Settings",
+    "application",
+r#"<activity
+    android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+    android:launchMode="singleTask"
+    android:label="@string/main_activity_title"
+    android:name=".MainActivity"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="com.android.settings.action.IA_SETTINGS" />
+    </intent-filter>
+    <meta-data android:name="com.android.settings.category"
+            android:value="com.android.settings.category.ia.homepage" />
+    <meta-data android:name="com.android.settings.summary"
+            android:resource="@string/main_activity_summary" />
+</activity>"#.to_string(),
+  )
+  .expect("Failed to update AndroidManifest.xml");
+
+  #[cfg(not(feature="system_settings"))]
+  tauri_plugin::mobile::update_android_manifest(
+    "Include in App Grid or System Settings",
+    "application",
+r#"<activity
+    android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+    android:launchMode="singleTask"
+    android:label="@string/main_activity_title"
+    android:name=".MainActivity"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+        <!-- AndroidTV support -->
+        <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+    </intent-filter>
+</activity>"#.to_string(),
+  )
+  .expect("Failed to update AndroidManifest.xml");
+
+  res
 }

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.mobile_conductor_admin"
         android:usesCleartextTraffic="${usesCleartextTraffic}">
+        
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:launchMode="singleTask"
@@ -17,11 +18,12 @@
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-                <!-- AndroidTV support -->
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+                <action android:name="com.android.settings.action.IA_SETTINGS" />
             </intent-filter>
+            <meta-data android:name="com.android.settings.category"
+                       android:value="com.android.settings.category.ia.homepage" />
+            <meta-data android:name="com.android.settings.summary"
+                       android:resource="@string/main_activity_summary" />
         </activity>
 
         <provider

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.mobile_conductor_admin"
         android:usesCleartextTraffic="${usesCleartextTraffic}">
-        
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:launchMode="singleTask"

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -10,20 +10,6 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.mobile_conductor_admin"
         android:usesCleartextTraffic="${usesCleartextTraffic}">
-        <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
-            android:launchMode="singleTask"
-            android:label="@string/main_activity_title"
-            android:name=".MainActivity"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.android.settings.action.IA_SETTINGS" />
-            </intent-filter>
-            <meta-data android:name="com.android.settings.category"
-                       android:value="com.android.settings.category.ia.homepage" />
-            <meta-data android:name="com.android.settings.summary"
-                       android:resource="@string/main_activity_summary" />
-        </activity>
 
         <provider
           android:name="androidx.core.content.FileProvider"
@@ -34,5 +20,20 @@
             android:name="android.support.FILE_PROVIDER_PATHS"
             android:resource="@xml/file_paths" />
         </provider>
+        <!-- Include in App Grid or System Settings. AUTO-GENERATED. DO NOT REMOVE. -->
+        <activity
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+            android:launchMode="singleTask"
+            android:label="@string/main_activity_title"
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <!-- AndroidTV support -->
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <!-- Include in App Grid or System Settings. AUTO-GENERATED. DO NOT REMOVE. -->
     </application>
 </manifest>

--- a/src-tauri/gen/android/app/src/main/res/values/strings.xml
+++ b/src-tauri/gen/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">mobile-conductor-admin</string>
     <string name="main_activity_title">mobile-conductor-admin</string>
+    <string name="main_activity_summary">mobile-conductor-admin</string>
 </resources>


### PR DESCRIPTION
Resolves #10 

The feature flag `system_settings` builds the app to be displayed on the settings page, otherwise it is included in the app grid.