### PR TITLE
Build: Disable java compile-time optimization

### DIFF
--- a/apps/android-service-runtime/src-tauri/gen/android/app/build.gradle.kts
+++ b/apps/android-service-runtime/src-tauri/gen/android/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
             }
         }
         getByName("release") {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }
                     .plus(getDefaultProguardFile("proguard-android-optimize.txt"))

--- a/crates/tauri-plugin-holochain-service-consumer/android/build.gradle.kts
+++ b/crates/tauri-plugin-holochain-service-consumer/android/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/crates/tauri-plugin-holochain-service/android/build.gradle.kts
+++ b/crates/tauri-plugin-holochain-service/android/build.gradle.kts
@@ -16,7 +16,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/examples/service-app/src-tauri/gen/android/app/build.gradle.kts
+++ b/examples/service-app/src-tauri/gen/android/app/build.gradle.kts
@@ -30,14 +30,15 @@ android {
             isDebuggable = true
             isJniDebuggable = true
             isMinifyEnabled = false
-            packaging {                jniLibs.keepDebugSymbols.add("*/arm64-v8a/*.so")
+            packaging {
+                jniLibs.keepDebugSymbols.add("*/arm64-v8a/*.so")
                 jniLibs.keepDebugSymbols.add("*/armeabi-v7a/*.so")
                 jniLibs.keepDebugSymbols.add("*/x86/*.so")
                 jniLibs.keepDebugSymbols.add("*/x86_64/*.so")
             }
         }
         getByName("release") {
-            isMinifyEnabled = true
+            isMinifyEnabled = false
             proguardFiles(
                 *fileTree(".") { include("**/*.pro") }
                     .plus(getDefaultProguardFile("proguard-android-optimize.txt"))


### PR DESCRIPTION
### Summary
Release builds of android-service-runtime were crashing when calling an ffi function. It was caused by the compile-time optimization, minimization and obfuscation work performed by R8 (see https://developer.android.com/build/shrink-code).

For now I just disabled the compile-time optimization. I created an issue to re-enable it later: #64 

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info