### PR TITLE
fix: delete duplicate types-ffi lib

### DIFF
--- a/crates/holochain-conductor-runtime-ffi/scripts/build-single-target.sh
+++ b/crates/holochain-conductor-runtime-ffi/scripts/build-single-target.sh
@@ -8,6 +8,9 @@ cargo ndk --manifest-path ./Cargo.toml -t $TARGET \
  -o ../tauri-plugin-holochain-service/android/src/main/jniLibs \
   build --release
 
+# Delete the types-ffi library from tauri-plugin-holochain-service, as it will be included via the dependency on holochain-service-client kotlin library
+find "../tauri-plugin-holochain-service/android/src/main/jniLibs/" -wholename '**/libholochain_conductor_runtime_types_ffi.so' -delete
+
 cargo run -p uniffi-bindgen-cli --release generate \
   --library ../../target/$TARGET/release/libholochain_conductor_runtime_ffi.so \
   --crate holochain_conductor_runtime_ffi \

--- a/crates/holochain-conductor-runtime-ffi/scripts/build.sh
+++ b/crates/holochain-conductor-runtime-ffi/scripts/build.sh
@@ -6,6 +6,9 @@ cargo ndk --manifest-path ./Cargo.toml -t arm64-v8a -t armeabi-v7a -t x86 -t x86
  -o ../tauri-plugin-holochain-service/android/src/main/jniLibs \
   build --release
 
+# Delete the types-ffi library from tauri-plugin-holochain-service, as it will be included via the dependency on holochain-service-client kotlin library
+find "../tauri-plugin-holochain-service/android/src/main/jniLibs/" -wholename '**/libholochain_conductor_runtime_types_ffi.so' -delete
+
 cargo run -p uniffi-bindgen-cli --release generate \
   --library ../../target/aarch64-linux-android/release/libholochain_conductor_runtime_ffi.so \
   --crate holochain_conductor_runtime_ffi \


### PR DESCRIPTION
### Summary
When `cargo ndk` builds the `-runtime-ffi` library and outputs it to `tauri-plugin-holochain-service`, it also builds the dependency library `-runtime-types-ffi`.

However, in a separate step we build the `-runtime-types-ffi` library and output it to the kotlin client.

This deletes the redundant library so that `tauri-plugin-holochain-service` only has one copy in its path, and doesn't complain about it.

Probably both these build scripts should be unified into one, but for just wanted to get this in for now so I don't hit the error again.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info