### PR TITLE
fix: avoid crash when navigating to 'my apps' page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,4 @@
 - Re-added ktlint for kotlin linting
 - Rename kotlin packages to resolve lint complaints
 - Rename library and crate directories to reduce noise
+- Fix bug in `apps/android-service-runtime`, where the app would crash if the service was not running when switching to the "My Apps" tab.

--- a/apps/android-service-runtime/src/pages/MyApps.svelte
+++ b/apps/android-service-runtime/src/pages/MyApps.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
 	import { onMount } from "svelte";
   import BaseInstalledAppCard from "../components/BaseInstalledAppCard.svelte";
-  import { apps, loadingApps, loadingToggleEnableApp, loadApps, toggleEnableApp } from "../stores/holochain";
+  import { apps, loadingApps, loadingToggleEnableApp, loadApps, toggleEnableApp, isRunning } from "../stores/holochain";
 
   onMount(() => {
-    loadApps();
+    if($isRunning) {
+      loadApps();
+    }
   });
 </script>
 
 <div class="flex justify-between items-center mx-4">
   <h4>Installed Apps</h4>
-  <button on:click={loadApps} class="btn btn-sm btn-circle btn-outline">
+  <button on:click={loadApps} disabled={!$isRunning} class="btn btn-sm btn-circle btn-outline">
     {#if $loadingApps}
       <span class="loading loading-spinner loading-xs"></span>
     {:else}
@@ -19,7 +21,9 @@
   </button>
 </div>
 
-{#if $apps.length > 0}
+{#if !$isRunning}
+  <div class="alert my-4">Start service to view installed apps</div>
+{:else if $apps.length > 0}
   {#each $apps as appInfo}
     <BaseInstalledAppCard 
       {appInfo} 
@@ -28,5 +32,5 @@
     />
   {/each} 
 {:else}
- <p class="text-center">No apps installed.</p>
+  <div class="alert my-4">No apps installed</div>
 {/if}


### PR DESCRIPTION
### Summary
Fixes issue in manager app, where navigating to "My Apps" would cause app to crash if service not running.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info