### PR TITLE
fix: avoid top-level await which is not supported by many web rendering engines

### DIFF
--- a/apps/android-service-runtime/src/App.svelte
+++ b/apps/android-service-runtime/src/App.svelte
@@ -3,16 +3,17 @@
   import Status from './pages/Status.svelte';
   import MyApps from './pages/MyApps.svelte';
   import Toasts from './components/Toasts.svelte';
-  import { _ } from 'svelte-i18n';
+  import { _, isLoading } from 'svelte-i18n';
 
   export let activeTab = 0;
 
   $: tabs = [
-    {text: $_('status'), component: Status},
-    {text: $_('my_apps'), component: MyApps},
+    {text_i18n_key: 'status', component: Status},
+    {text_i18n_key: 'my_apps', component: MyApps},
   ];
 </script>
 
+{#if !$isLoading}
 <nav class="navbar bg-base-100 border-b-2 border-gray-300 fixed top-0 z-50">
   <div class="flex-1">
     <span class="btn btn-ghost text-xl">{$_('app_title')}</span>
@@ -25,8 +26,9 @@
 
 <div role="tablist" class="tabs tabs-boxed tabs-lg fixed bottom-0 w-full bg-base-100 border-t-2 border-gray-300 z-50">
   {#each tabs as tab, i}
-    <button role="tab" class={`tab ${activeTab === i ? 'tab-active' : ''}`} on:click={() => (activeTab = i)}>{tab.text}</button>
+    <button role="tab" class={`tab ${activeTab === i ? 'tab-active' : ''}`} on:click={() => (activeTab = i)}>{$_(tab.text_i18n_key)}</button>
   {/each}
 </div>
 
 <Toasts />
+{/if}

--- a/apps/android-service-runtime/src/main.js
+++ b/apps/android-service-runtime/src/main.js
@@ -1,10 +1,8 @@
 import "./style.css";
 import App from "./App.svelte";
 import { initTranslations } from './translations';
-import { waitLocale } from "svelte-i18n";
 
 initTranslations();
-await waitLocale();
 
 const app = new App({
   target: document.getElementById("app"),


### PR DESCRIPTION
### Summary
Follow up to #114 
Avoid top-level await which is not supported by many web rendering engines and thus was blocking builds of android-service-runtime app.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] docs updated (`pnpm run build:doc`)