### PR TITLE
feat: move runtime settings link from settings homepage to settings > system

### DIFF
--- a/apps/android-service-runtime/src-tauri/build.rs
+++ b/apps/android-service-runtime/src-tauri/build.rs
@@ -15,7 +15,7 @@ r#"<activity
         <action android:name="com.android.settings.action.IA_SETTINGS" />
     </intent-filter>
     <meta-data android:name="com.android.settings.category"
-            android:value="com.android.settings.category.ia.homepage" />
+            android:value="com.android.settings.category.ia.system" />
     <meta-data android:name="com.android.settings.summary"
             android:resource="@string/main_activity_title" />
 </activity>"#.to_string(),


### PR DESCRIPTION
### Summary
Duplicate of #129, debugging why CI is failing


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] docs updated (`pnpm run build:doc`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android Settings integration to appear under the System category, improving organization and discoverability.
  * No impact to non-system settings builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->