### PR TITLE
Chore: bump the tauri-plugin-holochain-service-client version to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7933,7 +7933,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-holochain-service-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bytes",
  "holochain-conductor-runtime-types-ffi",

--- a/crates/tauri-plugin-client/Cargo.toml
+++ b/crates/tauri-plugin-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-holochain-service-client"
-version = "0.2.2"
+version = "0.2.3"
 exclude = ["/examples", "/webview-dist", "/webview-src", "/node_modules"]
 links = "tauri-plugin-holochain-service-client"
 description = "Tauri plugin enabling an Android app to run as a client of the tauri-plugin-holochain-service"


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] docs updated (`pnpm run build:doc`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.2.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->