### PR TITLE
chore: released @holochain/client 0.21.0 + gate desktop plugin suite in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ test: static integration-test
 integration-test:
 	RUST_BACKTRACE=1 RUST_LOG=info cargo test -p holochain-conductor-runtime -- --nocapture
 	RUST_BACKTRACE=1 RUST_LOG=info cargo test -p holochain-conductor-runtime-ffi -- --nocapture
+	RUST_BACKTRACE=1 RUST_LOG=info cargo test -p tauri-plugin-holochain -- --nocapture
+	pnpm run test:example
 
 static: fmt lint
 	@if [ "${CI}x" != "x" ]; then git diff --exit-code; fi

--- a/apps/android-service-runtime/package.json
+++ b/apps/android-service-runtime/package.json
@@ -14,7 +14,7 @@
 		"build:android": "tauri android build"
 	},
 	"dependencies": {
-		"@holochain/client": "file:../../../holochain-client-js",
+		"@holochain/client": "^0.21.0",
 		"@msgpack/msgpack": "^3.1.2",
 		"@tauri-apps/api": "^2.5.0",
 		"async-retry": "^1.3.3",

--- a/apps/example-client-app/tests/package.json
+++ b/apps/example-client-app/tests/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@msgpack/msgpack": "^3.1.2",
-    "@holochain/client": "file:../../../../holochain-client-js",
+    "@holochain/client": "^0.21.0",
     "@holochain-open-dev/tryorama": "^0.20.0-dev.0",
     "typescript": "^4.9.4",
     "vitest": "^0.28.4"

--- a/apps/example-client-app/ui/package.json
+++ b/apps/example-client-app/ui/package.json
@@ -7,7 +7,7 @@
     "package": "npm run build && rimraf dist.zip && cd dist && bestzip ../dist.zip *"
   },
   "dependencies": {
-    "@holochain/client": "file:../../../../holochain-client-js",
+    "@holochain/client": "^0.21.0",
     "@msgpack/msgpack": "^3.1.2",
     "uuid": "^11.1.0"
   },

--- a/apps/holochain-runtime-example/ui/package.json
+++ b/apps/holochain-runtime-example/ui/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@holochain/client": "file:../../../../holochain-client-js"
+    "@holochain/client": "^0.21.0"
   },
   "devDependencies": {
     "vite": "^6.2.5"

--- a/crates/tauri-plugin-client/package.json
+++ b/crates/tauri-plugin-client/package.json
@@ -31,7 +31,7 @@
     "prepare": "pnpm build:js"
   },
   "dependencies": {
-    "@holochain/client": "file:../../../holochain-client-js",
+    "@holochain/client": "^0.21.0",
     "@tauri-apps/api": "^2.5.0",
     "@msgpack/msgpack": "^3.1.2"
   },

--- a/crates/tauri-plugin-holochain/package.json
+++ b/crates/tauri-plugin-holochain/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build:js"
   },
   "dependencies": {
-    "@holochain/client": "file:../../../holochain-client-js",
+    "@holochain/client": "^0.21.0",
     "@msgpack/msgpack": "^3.1.2",
     "@tauri-apps/api": "^2.5.0"
   },

--- a/crates/tauri-plugin-service/package.json
+++ b/crates/tauri-plugin-service/package.json
@@ -31,7 +31,7 @@
     "prepare": "pnpm build:js"
   },
   "dependencies": {
-    "@holochain/client": "file:../../../holochain-client-js",
+    "@holochain/client": "^0.21.0",
     "@tauri-apps/api": "^2.5.0",
     "@msgpack/msgpack": "^3.1.2"
   },

--- a/docs/holochain-0.7-update-plan.md
+++ b/docs/holochain-0.7-update-plan.md
@@ -56,14 +56,13 @@ Rust side compiles clean (`cargo check --workspace --all-targets`: 0 warnings;
 Goal: `holochain-runtime-example` (desktop Tauri app embedding
 `tauri-plugin-holochain`) installs, runs, and rebinds apps against 0.7.0.
 
-1. **JS client to released 0.21.** All `package.json`s point
-   `@holochain/client` at `file:../../../holochain-client-js` (local dev
-   checkout). Switch to the released `^0.21.0` from npm in:
-   `crates/tauri-plugin-holochain`, `apps/holochain-runtime-example/ui`,
-   `apps/android-service-runtime`, `crates/tauri-plugin-{client,service}`,
-   `apps/example-client-app/{ui,tests}`. Then rebuild the injected env bundle
-   (`dist-js/holochain-env/index.min.js`) — the staleness guard added on
-   `main-0.6` will fail the build if this is skipped.
+1. **JS client to released 0.21.** DONE — all seven `package.json`s moved from
+   the `file:../../../holochain-client-js` dev checkout (which was at
+   0.21.0-rc.1) to the released `^0.21.0` from npm; the pnpm workspace
+   lockfile regenerated (pnpm 11 build-script approvals recorded in
+   `pnpm-workspace.yaml`). The rebuilt `dist-js/holochain-env/index.min.js`
+   came out byte-identical (the client import is type-only), confirming the
+   shipped bundle is current — the staleness-guard test agrees.
 2. **Local validation.**
    - `cargo test -p holochain-conductor-runtime` and `-p
      holochain-conductor-runtime-ffi` (conductor lifecycle, install/enable,
@@ -73,16 +72,15 @@ Goal: `holochain-runtime-example` (desktop Tauri app embedding
    - `pnpm run test:example` — builds the desktop example against the plugin.
    - Manual smoke: `pnpm run start:example` in the dev shell (webkit pin).
 3. **CI validation.**
-   - `test.yml` (PRs to `main-*`) runs `make integration-test` in the nix
-     shell. Add the desktop plugin suite so it's actually gated in CI:
-     `integration-test` should also run
-     `cargo test -p tauri-plugin-holochain` and build the example
-     (`pnpm run test:example`). Today those exist only as pnpm scripts and CI
-     never runs them.
+   - DONE — `make integration-test` now also runs
+     `cargo test -p tauri-plugin-holochain` and `pnpm run test:example`, so
+     the desktop plugin suite and example build are gated by `test.yml` on
+     PRs to `main-*`.
    - The `static` target (fmt + clippy + `git diff --exit-code`) already gates
      the dist-js staleness guard output.
-   - Open a PR against `main-0.7` (branch pattern `main-*` already triggers
-     `test.yml` + `build.yml`) and require both green.
+   - Remaining: land these changes via a PR against `main-0.7` and require
+     `test.yml` + `build.yml` green. The stale draft #140 (old
+     `asr-main-0.7` lineage) is superseded by `main-0.7`.
 
 ## Phase 2 — Android: service/client crates + Kotlin libraries
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   apps/android-service-runtime:
     dependencies:
       '@holochain/client':
-        specifier: file:../../../holochain-client-js
-        version: file:../holochain-client-js(bufferutil@4.0.8)
+        specifier: ^0.21.0
+        version: 0.21.0(bufferutil@4.0.8)
       '@msgpack/msgpack':
         specifier: ^3.1.2
         version: 3.1.2
@@ -41,7 +41,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^1.0.1
-        version: 1.4.0(svelte@3.59.2)(vite@3.2.11(@types/node@20.17.46)(terser@5.39.0))
+        version: 1.4.0(supports-color@8.1.1)(svelte@3.59.2)(vite@3.2.11(@types/node@20.17.46)(terser@5.39.0))
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.16(tailwindcss@3.4.17)
@@ -59,13 +59,13 @@ importers:
         version: 4.12.24(postcss@8.5.3)
       eslint:
         specifier: ^9.7.0
-        version: 9.21.0(jiti@1.21.7)
+        version: 9.21.0(jiti@1.21.7)(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.0(eslint@9.21.0(jiti@1.21.7))
+        version: 9.1.0(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-svelte:
         specifier: ^2.36.0
-        version: 2.46.1(eslint@9.21.0(jiti@1.21.7))(svelte@3.59.2)
+        version: 2.46.1(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1))(svelte@3.59.2)
       globals:
         specifier: ^15.0.0
         version: 15.15.0
@@ -89,7 +89,7 @@ importers:
     devDependencies:
       '@holochain/hc-spin':
         specifier: ^0.600.0-rc.0
-        version: 0.600.0
+        version: 0.600.0(supports-color@8.1.1)
       '@tauri-apps/cli':
         specifier: ^2.5.0
         version: 2.5.0
@@ -100,8 +100,8 @@ importers:
   apps/example-client-app/ui:
     dependencies:
       '@holochain/client':
-        specifier: file:../../../../holochain-client-js
-        version: file:../holochain-client-js(bufferutil@4.0.8)
+        specifier: ^0.21.0
+        version: 0.21.0(bufferutil@4.0.8)
       '@msgpack/msgpack':
         specifier: ^3.1.2
         version: 3.1.2
@@ -111,7 +111,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.2
-        version: 3.1.2(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
+        version: 3.1.2(supports-color@8.1.1)(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.8
@@ -137,8 +137,8 @@ importers:
   crates/tauri-plugin-client:
     dependencies:
       '@holochain/client':
-        specifier: file:../../../holochain-client-js
-        version: file:../holochain-client-js(bufferutil@4.0.8)
+        specifier: ^0.21.0
+        version: 0.21.0(bufferutil@4.0.8)
       '@msgpack/msgpack':
         specifier: ^3.1.2
         version: 3.1.2
@@ -165,8 +165,8 @@ importers:
   crates/tauri-plugin-service:
     dependencies:
       '@holochain/client':
-        specifier: file:../../../holochain-client-js
-        version: file:../holochain-client-js(bufferutil@4.0.8)
+        specifier: ^0.21.0
+        version: 0.21.0(bufferutil@4.0.8)
       '@msgpack/msgpack':
         specifier: ^3.1.2
         version: 3.1.2
@@ -579,9 +579,9 @@ packages:
     resolution: {integrity: sha512-BONSMX3z349broeNaITnq9tOb+tV7DuHuPRHwJBYGZihEhHSSXBx9pWHTHwF/HKBFb/DGovY62VfK0MzfWIMEg==}
     engines: {node: '>=18.0.0 || >=20.0.0 || >= 22.0.0'}
 
-  '@holochain/client@file:../holochain-client-js':
-    resolution: {directory: ../holochain-client-js, type: directory}
-    engines: {node: '>=20.0.0'}
+  '@holochain/client@0.21.0':
+    resolution: {integrity: sha512-o1Fzu/9LXWSb1zP21sLXvhTihUKs/5r4ZEFKQW/e9MPogHiMsyt3/6AYKB+X0ZcUilC5sBSFODIAifRu0XMQqA==}
+    engines: {node: '>=22.0.0'}
 
   '@holochain/hc-spin-rust-utils-darwin-arm64@0.600.0':
     resolution: {integrity: sha512-tvU5vBHkkGRSD9K+3HWkTySX7XK+vdD35x3x/4pQ5J/31gRMKcRbrP0W1n7mTOyFUWQjgNHnLJeTM3yt2a7tbA==}
@@ -600,12 +600,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@holochain/hc-spin-rust-utils-linux-x64-gnu@0.600.0':
     resolution: {integrity: sha512-nr2prm4tlB3inRnQANc6W2M/8JleBTWbleSJ4tdFmS0U2xjoKBLGYmp6TjeTwLAod/99qCNiYoVFblQhxWcZ4w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@holochain/hc-spin-rust-utils-win32-x64-msvc@0.600.0':
     resolution: {integrity: sha512-RRyyN+51o7E8TuaKtS3xTAOyh2vVa39dhvY7Tr9EQLxSI9EO1xn4nM+3ZYqSCKPiSUlZ44DwOSrwgmbm2o/9xg==}
@@ -754,51 +756,61 @@ packages:
     resolution: {integrity: sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.9':
     resolution: {integrity: sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.9':
     resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.9':
     resolution: {integrity: sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.9':
     resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.9':
     resolution: {integrity: sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.9':
     resolution: {integrity: sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.9':
     resolution: {integrity: sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.9':
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.9':
     resolution: {integrity: sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==}
@@ -899,54 +911,63 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-gnu@2.5.0':
     resolution: {integrity: sha512-mTQufsPcpdHg5RW0zypazMo4L55EfeE5snTzrPqbLX4yCK2qalN7+rnP8O8GT06xhp6ElSP/Ku1M2MR297SByQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.3.1':
     resolution: {integrity: sha512-tqQkafikGfnc7ISnGjSYkbpnzJKEyO8XSa0YOXTAL3J8R5Pss5ZIZY7G8kq1mwQSR/dPVR1ZLTVXgZGuysjP8w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-arm64-musl@2.5.0':
     resolution: {integrity: sha512-rQO1HhRUQqyEaal5dUVOQruTRda/TD36s9kv1hTxZiFuSq3558lsTjAcUEnMAtBcBkps20sbyTJNMT0AwYIk8Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.5.0':
     resolution: {integrity: sha512-7oS18FN46yDxyw1zX/AxhLAd7T3GrLj3Ai6s8hZKd9qFVzrAn36ESL7d3G05s8wEtsJf26qjXnVF4qleS3dYsA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.3.1':
     resolution: {integrity: sha512-I3puDJ2wGEauXlXbzIHn2etz78TaWs1cpN6zre02maHr6ZR7nf7euTCOGPhhfoMG0opA5mT/eLuYpVw648/VAA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.5.0':
     resolution: {integrity: sha512-SG5sFNL7VMmDBdIg3nO3EzNRT306HsiEQ0N90ILe3ZABYAVoPDO/ttpCO37ApLInTzrq/DLN+gOlC/mgZvLw1w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.3.1':
     resolution: {integrity: sha512-rbWiCOBuQN7tPySkUyBs914uUikE3mEUOqV/IFospvKESw4UC3G1DL5+ybfXH7Orb8/in3JpJuVzYQjo+OSbBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-QXDM8zp/6v05PNWju5ELsVwF0VH1n6b5pk2E6W/jFbbiwz80Vs1lACl9pv5kEHkrxBj+aWU/03JzGuIj2g3SkQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.3.1':
     resolution: {integrity: sha512-PdTmUzSeTHjJuBpCV7L+V29fPhPtToU+NZU46slHKSA1aT38MiFDXBZ/6P5Zudrt9QPMfIubqnJKbK8Ivvv7Ww==}
@@ -1742,7 +1763,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -2766,23 +2787,23 @@ snapshots:
       '@bitgo/blake2b-wasm': 3.2.3
       nanoassert: 2.0.0
 
-  '@electron-toolkit/preload@3.0.2(electron@29.4.6)':
+  '@electron-toolkit/preload@3.0.2(electron@29.4.6(supports-color@8.1.1))':
     dependencies:
-      electron: 29.4.6
+      electron: 29.4.6(supports-color@8.1.1)
 
-  '@electron-toolkit/utils@3.0.0(electron@29.4.6)':
+  '@electron-toolkit/utils@3.0.0(electron@29.4.6(supports-color@8.1.1))':
     dependencies:
-      electron: 29.4.6
+      electron: 29.4.6(supports-color@8.1.1)
 
-  '@electron/get@2.0.3':
+  '@electron/get@2.0.3(supports-color@8.1.1)':
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
       progress: 2.0.3
       semver: 6.3.1
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@8.1.1)
     optionalDependencies:
       global-agent: 3.0.0
     transitivePeerDependencies:
@@ -2941,17 +2962,17 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.1(eslint@9.21.0(jiti@1.21.7))':
+  '@eslint-community/eslint-utils@4.4.1(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1))':
     dependencies:
-      eslint: 9.21.0(jiti@1.21.7)
+      eslint: 9.21.0(jiti@1.21.7)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/config-array@0.19.2':
+  '@eslint/config-array@0.19.2(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2960,10 +2981,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.0':
+  '@eslint/eslintrc@3.3.0(supports-color@8.1.1)':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -3024,7 +3045,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@holochain/client@file:../holochain-client-js(bufferutil@4.0.8)':
+  '@holochain/client@0.21.0(bufferutil@4.0.8)':
     dependencies:
       '@bitgo/blake2b': 3.2.4
       '@msgpack/msgpack': 3.1.2
@@ -3062,16 +3083,16 @@ snapshots:
       '@holochain/hc-spin-rust-utils-linux-x64-gnu': 0.600.0
       '@holochain/hc-spin-rust-utils-win32-x64-msvc': 0.600.0
 
-  '@holochain/hc-spin@0.600.0':
+  '@holochain/hc-spin@0.600.0(supports-color@8.1.1)':
     dependencies:
-      '@electron-toolkit/preload': 3.0.2(electron@29.4.6)
-      '@electron-toolkit/utils': 3.0.0(electron@29.4.6)
+      '@electron-toolkit/preload': 3.0.2(electron@29.4.6(supports-color@8.1.1))
+      '@electron-toolkit/utils': 3.0.0(electron@29.4.6(supports-color@8.1.1))
       '@holochain/client': 0.20.5(bufferutil@4.0.8)
       '@holochain/hc-spin-rust-utils': 0.600.0
       '@msgpack/msgpack': 2.8.0
       bufferutil: 4.0.8
       commander: 11.1.0
-      electron: 29.4.6
+      electron: 29.4.6(supports-color@8.1.1)
       electron-context-menu: 3.6.1
       get-port: 7.0.0
       js-sha512: 0.9.0
@@ -3238,18 +3259,18 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0)))(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(supports-color@8.1.1)(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0)))(supports-color@8.1.1)(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
-      debug: 4.4.0
+      '@sveltejs/vite-plugin-svelte': 3.1.2(supports-color@8.1.1)(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
+      debug: 4.4.0(supports-color@8.1.1)
       svelte: 5.56.3
       vite: 6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@1.4.0(svelte@3.59.2)(vite@3.2.11(@types/node@20.17.46)(terser@5.39.0))':
+  '@sveltejs/vite-plugin-svelte@1.4.0(supports-color@8.1.1)(svelte@3.59.2)(vite@3.2.11(@types/node@20.17.46)(terser@5.39.0))':
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.26.7
@@ -3260,10 +3281,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.2(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@3.1.2(supports-color@8.1.1)(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0)))(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
-      debug: 4.4.0
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.2(supports-color@8.1.1)(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0)))(supports-color@8.1.1)(svelte@5.56.3)(vite@6.4.3(@types/node@20.17.46)(jiti@1.21.7)(terser@5.39.0)(yaml@2.7.0))
+      debug: 4.4.0(supports-color@8.1.1)
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.17
@@ -3701,9 +3722,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.1
 
-  debug@4.4.0:
+  debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js@10.5.0: {}
 
@@ -3758,11 +3781,11 @@ snapshots:
 
   electron-to-chromium@1.5.113: {}
 
-  electron@29.4.6:
+  electron@29.4.6(supports-color@8.1.1):
     dependencies:
-      '@electron/get': 2.0.3
+      '@electron/get': 2.0.3(supports-color@8.1.1)
       '@types/node': 20.17.46
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3958,21 +3981,21 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.21.0(jiti@1.21.7)):
+  eslint-compat-utils@0.5.1(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.21.0(jiti@1.21.7)
+      eslint: 9.21.0(jiti@1.21.7)(supports-color@8.1.1)
       semver: 7.7.1
 
-  eslint-config-prettier@9.1.0(eslint@9.21.0(jiti@1.21.7)):
+  eslint-config-prettier@9.1.0(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.21.0(jiti@1.21.7)
+      eslint: 9.21.0(jiti@1.21.7)(supports-color@8.1.1)
 
-  eslint-plugin-svelte@2.46.1(eslint@9.21.0(jiti@1.21.7))(svelte@3.59.2):
+  eslint-plugin-svelte@2.46.1(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1))(svelte@3.59.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1))
       '@jridgewell/sourcemap-codec': 1.5.0
-      eslint: 9.21.0(jiti@1.21.7)
-      eslint-compat-utils: 0.5.1(eslint@9.21.0(jiti@1.21.7))
+      eslint: 9.21.0(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-compat-utils: 0.5.1(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1))
       esutils: 2.0.3
       known-css-properties: 0.35.0
       postcss: 8.5.3
@@ -4000,13 +4023,13 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.21.0(jiti@1.21.7):
+  eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.21.0(jiti@1.21.7)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.19.2
+      '@eslint/config-array': 0.19.2(supports-color@8.1.1)
       '@eslint/core': 0.12.0
-      '@eslint/eslintrc': 3.3.0
+      '@eslint/eslintrc': 3.3.0(supports-color@8.1.1)
       '@eslint/js': 9.21.0
       '@eslint/plugin-kit': 0.2.7
       '@humanfs/node': 0.16.6
@@ -4017,7 +4040,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -4098,9 +4121,9 @@ snapshots:
     dependencies:
       type: 2.7.3
 
-  extract-zip@2.0.1:
+  extract-zip@2.0.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -4872,9 +4895,9 @@ snapshots:
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
 
-  sumchecker@3.0.1:
+  sumchecker@3.0.1(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,10 @@ packages:
   - '!**/android/**'
   - '!**/dist-js/**'
   - '!**/permissions/**'
+allowBuilds:
+  bufferutil: true
+  electron: true
+  es5-ext: true
+  esbuild: true
+minimumReleaseAgeExclude:
+  - '@holochain/client@0.21.0'


### PR DESCRIPTION
Completes Phase 1 of docs/holochain-0.7-update-plan.md (holochain 0.7.0 desktop target):

## JS client to released 0.21.0
- All seven `package.json`s move `@holochain/client` from the local `file:../holochain-client-js` checkout (which was at 0.21.0-rc.1) to the released `^0.21.0` from npm.
- pnpm workspace lockfile regenerated; pnpm 11 build-script approvals (bufferutil, electron, es5-ext, esbuild) recorded in `pnpm-workspace.yaml` so installs don't fail on `ERR_PNPM_IGNORED_BUILDS`.
- `dist-js/holochain-env/index.min.js` rebuilt against the released client — byte-identical (the client import is type-only), confirming the shipped bundle is current; the staleness-guard integration test passes.

## CI wiring
- `make integration-test` now also runs `cargo test -p tauri-plugin-holochain` and `pnpm run test:example`, so `test.yml` gates the desktop plugin suite and the example build on PRs to `main-*`.

Verified locally in the nix dev shell: `test:example` builds the UI + example app against 0.21.0; tauri-plugin-holochain integration suite 6/6 (incl. window rebind and bundle guard).

Supersedes the remaining scope of draft #140 (old `asr-main-0.7` lineage, pre-release 0.7-dev).