### PR TITLE
feat: typed install_app errors, payload signing, and lair error detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- `Runtime::install_app` preserves the typed `ConductorError` (as `RuntimeError::Conductor`) instead of flattening it to a string.
 - Bump to holochain 0.7.0. New conductor types are carried across the FFI: `AppStatusFfi` gains `AwaitingRestore` and `Unrecoverable` (cell id + rendered reason); `InstallAppPayload.restore_from_dht` and `RoleSettings::Provisioned.init_properties` are not exposed over FFI yet (always `false`/`None`).
 - BREAKING: `RuntimeNetworkConfig` / `RuntimeNetworkConfigFfi` lose `signal_url` and `ice_urls` — holochain 0.7 dropped the tx5/WebRTC transport in favor of iroh, so the conductor `NetworkConfig` no longer carries them. Only `bootstrap_url` and `relay_url` remain.
 - The forum test fixture is repacked with hdk 0.7.0 / hdi 0.8.0 (the 0.7 `Action`/`ActionData` restructure required porting the coordinator zome's signal emission).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- `Runtime::sign_payload` signs an arbitrary payload with a caller-chosen agent key via the keystore, for protocols beyond zome calls that need proof of control over an identity. Exposed through the in-process plugin as the `sign_payload` command, returning a base64-encoded signature.
 - `Runtime::install_app` preserves the typed `ConductorError` (as `RuntimeError::Conductor`) instead of flattening it to a string.
 - Bump to holochain 0.7.0. New conductor types are carried across the FFI: `AppStatusFfi` gains `AwaitingRestore` and `Unrecoverable` (cell id + rendered reason); `InstallAppPayload.restore_from_dht` and `RoleSettings::Provisioned.init_properties` are not exposed over FFI yet (always `false`/`None`).
 - BREAKING: `RuntimeNetworkConfig` / `RuntimeNetworkConfigFfi` lose `signal_url` and `ice_urls` — holochain 0.7 dropped the tx5/WebRTC transport in favor of iroh, so the conductor `NetworkConfig` no longer carries them. Only `bootstrap_url` and `relay_url` remain.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9253,6 +9253,7 @@ dependencies = [
 name = "tauri-plugin-holochain"
 version = "0.2.2"
 dependencies = [
+ "base64 0.22.1",
  "holochain",
  "holochain-conductor-runtime",
  "holochain-conductor-runtime-types-ffi",

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -31,7 +31,7 @@ pub enum RuntimeError {
     #[error("Failed to sign zome call {0}")]
     ZomeCallParamsInvalid(String),
 
-    #[error("Lair Error")]
+    #[error("Lair Error: {0}")]
     Lair(OneErr),
 
     #[error("hc-auth error: {0}")]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub use hc_auth::{HcAuthConfig, HcAuthStatus};
 
 mod error;
 pub use error::*;
+pub use holochain::conductor::error::ConductorError;
 
 mod config;
 pub use config::*;

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -329,13 +329,20 @@ impl Runtime {
     }
 
     pub async fn install_app(&self, payload: InstallAppPayload) -> RuntimeResult<AppInfo> {
-        let response = self
-            .req_admin_api(AdminRequest::InstallApp(Box::new(payload)))
-            .await?;
-        match response {
-            AdminResponse::AppInstalled(app_info) => Ok(app_info),
-            fail => Err(RuntimeError::AdminApiBadResponse(Box::new(fail))),
-        }
+        // Install against the conductor handle directly rather than through
+        // `AdminInterfaceApi::handle_request`, which flattens every error into a
+        // print-only `ExternalApiWireError::InternalError(String)` (holochain TODO
+        // B-01506). Going direct preserves the typed `ConductorError` — surfaced as
+        // `RuntimeError::Conductor` — so callers can match on the actual failure
+        // instead of grepping a Debug string. We lose `handle_request`'s implicit
+        // `check_running` guard, so run it here for fast-fail + parity with the
+        // sibling `req_admin_api` calls.
+        self.conductor.check_running()?;
+        let app = self.conductor.clone().install_app_bundle(payload).await?;
+        // Mirror the conductor's admin `InstallApp` handler: resolve the app's DNA
+        // definitions and build the same `AppInfo` it would have returned.
+        let dna_definitions = self.conductor.get_dna_definitions(&app).await?;
+        Ok(AppInfo::from_installed_app(&app, &dna_definitions))
     }
 
     pub async fn uninstall_app(&self, installed_app_id: String) -> RuntimeResult<()> {
@@ -851,7 +858,7 @@ impl Runtime {
 
 #[cfg(test)]
 mod test {
-    use crate::RuntimeNetworkConfig;
+    use crate::{ConductorError, RuntimeNetworkConfig};
 
     use super::*;
     use holochain::conductor::api::CellInfo::Provisioned;
@@ -1007,6 +1014,57 @@ mod test {
 
         let apps = runtime.list_apps().await.unwrap();
         assert_eq!(apps.len(), 1);
+    }
+
+    /// Re-installing an already-present `installed_app_id` surfaces the conductor's
+    /// own typed `ConductorError::AppAlreadyInstalled` (carrying the app id) through
+    /// `RuntimeError::Conductor` — so a consumer can detect the benign case with a
+    /// `matches!` instead of a `format!("{e:?}").contains(..)` Debug-string grep.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_install_app_already_installed() {
+        let tmp_dir = TempDir::new().unwrap();
+        let runtime = Runtime::new(
+            Arc::new(Mutex::new(LockedArray::from(vec![0, 0, 0, 0]))),
+            RuntimeConfig {
+                data_root_path: tmp_dir.path().into(),
+                network: RuntimeNetworkConfig::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // First install of this id succeeds.
+        let original = install_happ_fixture(runtime.clone(), "my-app-1").await;
+
+        // Re-installing the same id fails with the typed conductor error. A fresh
+        // network_seed proves the conflict is keyed on the app id, not the bundle.
+        let err = runtime
+            .install_app(InstallAppPayload {
+                source: AppBundleSource::Bytes(HAPP_FIXTURE.to_vec().into()),
+                agent_key: None,
+                installed_app_id: Some("my-app-1".into()),
+                network_seed: Some(Uuid::new_v4().to_string()),
+                roles_settings: Some(HashMap::new()),
+                ignore_genesis_failure: false,
+                restore_from_dht: false,
+            })
+            .await
+            .expect_err("re-installing an existing app id must fail");
+
+        assert!(
+            matches!(&err, RuntimeError::Conductor(ce)
+                if matches!(&**ce, ConductorError::AppAlreadyInstalled(id) if id == "my-app-1")),
+            "expected RuntimeError::Conductor(ConductorError::AppAlreadyInstalled(\"my-app-1\")), got: {err:?}"
+        );
+
+        // The failed re-install left the original app untouched — not just the same
+        // count, but the same agent key and cells. Had the fresh-seed re-install
+        // wrongly replaced it, the surviving app's provisioned DNA hash would differ.
+        let apps = runtime.list_apps().await.unwrap();
+        assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0].installed_app_id, original.installed_app_id);
+        assert_eq!(apps[0].agent_pub_key, original.agent_pub_key);
+        assert_eq!(apps[0].cell_info, original.cell_info);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -662,6 +662,43 @@ impl Runtime {
         })
     }
 
+    /// Sign arbitrary `payload` bytes with `agent_key`, returning the raw
+    /// 64-byte Ed25519 signature.
+    ///
+    /// General-purpose counterpart to [`Runtime::sign_zome_call`] (which signs
+    /// one fixed, structured payload): this signs whatever bytes the caller
+    /// supplies, for any protocol that needs proof of control over a
+    /// Holochain agent key.
+    ///
+    /// `agent_key` selects which identity signs. There is no default. A
+    /// single keystore can hold more than one signable identity at once (for
+    /// example [`Runtime::device_agent_key`] and, once hc-auth has run,
+    /// [`Runtime::hc_auth_agent_key`] are two distinct keys live in the same
+    /// keystore), and they are not interchangeable: a signature from the
+    /// wrong key is still a *valid* signature, just for the wrong identity,
+    /// so a caller that guesses wrong gets a confusing downstream rejection
+    /// rather than an error here. Callers must pass the exact key they mean.
+    ///
+    /// Fails with [`RuntimeError::Lair`] if the keystore does not hold the
+    /// private half of `agent_key` (a foreign key, or one whose public half
+    /// alone was imported) or the keystore is locked.
+    pub async fn sign_payload(
+        &self,
+        agent_key: AgentPubKey,
+        payload: Vec<u8>,
+    ) -> RuntimeResult<[u8; 64]> {
+        let mut pub_key_32 = [0u8; 32];
+        pub_key_32.copy_from_slice(agent_key.get_raw_32());
+        let signature = self
+            .conductor
+            .keystore()
+            .lair_client()
+            .sign_by_pub_key(pub_key_32.into(), None, Arc::from(payload.as_slice()))
+            .await
+            .map_err(RuntimeError::Lair)?;
+        Ok(*signature.0)
+    }
+
     pub async fn ensure_app_websocket(
         &self,
         installed_app_id: InstalledAppId,
@@ -1414,6 +1451,127 @@ mod test {
             })
             .await;
         assert!(res.is_ok())
+    }
+
+    /// A signature `sign_payload` returns must be a genuine Ed25519 signature
+    /// over exactly the given payload and key, not merely "no error". Verified
+    /// independently via `sodoken`'s pure-libsodium `verify_detached`, the same
+    /// primitive lair itself signs with, rather than trusting the signing path
+    /// to also grade its own output.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sign_payload_returns_a_verifiable_signature() {
+        let tmp_dir = TempDir::new().unwrap();
+        let runtime = Runtime::new(
+            Arc::new(Mutex::new(LockedArray::from(vec![0, 0, 0, 0]))),
+            RuntimeConfig {
+                data_root_path: tmp_dir.path().into(),
+                network: RuntimeNetworkConfig::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let agent_key = runtime.device_agent_key();
+        let payload = b"arbitrary payload bytes, not a zome call".to_vec();
+
+        let signature = runtime
+            .sign_payload(agent_key.clone(), payload.clone())
+            .await
+            .expect("signing with a key this keystore holds must succeed");
+
+        let mut pub_key_32 = [0u8; 32];
+        pub_key_32.copy_from_slice(agent_key.get_raw_32());
+        assert!(
+            sodoken::sign::verify_detached(&signature, &payload, &pub_key_32),
+            "returned signature must verify against the signing key and payload"
+        );
+    }
+
+    /// The signing key is exactly what the caller passes in, never a silent
+    /// default. Two distinct keys held by the *same* keystore, signing the
+    /// *same* payload, must produce two distinct signatures, each verifying
+    /// only against its own key. This is the trap the API is designed against:
+    /// a caller that means to sign with one identity must not be able to get a
+    /// signature that quietly verifies against a different one instead.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sign_payload_binds_the_signature_to_the_requested_key_not_a_default() {
+        let tmp = TempDir::new().unwrap();
+        let runtime = boot_runtime(&tmp, None).await;
+
+        let device_key = runtime.device_agent_key();
+        let other_key = runtime.import_key_seed([5u8; 32]).await.unwrap();
+        assert_ne!(device_key, other_key);
+
+        let payload = b"same payload, two identities".to_vec();
+        let sig_device = runtime
+            .sign_payload(device_key.clone(), payload.clone())
+            .await
+            .unwrap();
+        let sig_other = runtime
+            .sign_payload(other_key.clone(), payload.clone())
+            .await
+            .unwrap();
+
+        assert_ne!(
+            sig_device, sig_other,
+            "different keys signing the same payload must produce different signatures"
+        );
+
+        let mut device_pk = [0u8; 32];
+        device_pk.copy_from_slice(device_key.get_raw_32());
+        let mut other_pk = [0u8; 32];
+        other_pk.copy_from_slice(other_key.get_raw_32());
+
+        assert!(sodoken::sign::verify_detached(
+            &sig_device,
+            &payload,
+            &device_pk
+        ));
+        assert!(sodoken::sign::verify_detached(
+            &sig_other, &payload, &other_pk
+        ));
+        // Cross-check: neither signature verifies against the other identity's key.
+        assert!(!sodoken::sign::verify_detached(
+            &sig_device,
+            &payload,
+            &other_pk
+        ));
+        assert!(!sodoken::sign::verify_detached(
+            &sig_other, &payload, &device_pk
+        ));
+    }
+
+    /// Signing with a key from a *different* keystore (mirrors
+    /// `test_install_with_foreign_key_fails_genesis`) must fail clearly rather
+    /// than silently fabricate a signature: the private half simply is not
+    /// present in this runtime's lair.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sign_payload_fails_when_the_key_is_not_in_this_keystore() {
+        let tmp1 = TempDir::new().unwrap();
+        let rt1 = boot_runtime(&tmp1, None).await;
+
+        let tmp2 = TempDir::new().unwrap();
+        let rt2 = boot_runtime(&tmp2, None).await;
+        let foreign_key = rt2.device_agent_key();
+        assert_ne!(foreign_key, rt1.device_agent_key());
+
+        let err = rt1
+            .sign_payload(foreign_key, b"payload".to_vec())
+            .await
+            .expect_err("signing with a key this keystore does not hold must fail");
+        assert!(
+            matches!(err, RuntimeError::Lair(_)),
+            "expected RuntimeError::Lair, got {err:?}"
+        );
+        // The Display must carry lair's own detail, not just the bare variant
+        // label. A caller (including the Tauri command's JSON error body)
+        // reads this string, and "Lair Error" alone can't distinguish a
+        // missing key from a locked keystore from any other lair failure.
+        let message = err.to_string();
+        assert!(
+            message.starts_with("Lair Error: ") && message.len() > "Lair Error: ".len(),
+            "expected the underlying lair error detail in the message, got: {message:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/tauri-plugin-holochain/Cargo.toml
+++ b/crates/tauri-plugin-holochain/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }
+base64 = "0.22"
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }

--- a/crates/tauri-plugin-holochain/build.rs
+++ b/crates/tauri-plugin-holochain/build.rs
@@ -1,4 +1,4 @@
-const COMMANDS: &[&str] = &["sign_zome_call", "app_request"];
+const COMMANDS: &[&str] = &["sign_zome_call", "sign_payload", "app_request"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/crates/tauri-plugin-holochain/permissions/default.toml
+++ b/crates/tauri-plugin-holochain/permissions/default.toml
@@ -1,3 +1,3 @@
 [default]
 description = "Default permissions for the in-process Holochain plugin"
-permissions = ["allow-sign-zome-call", "allow-app-request"]
+permissions = ["allow-sign-zome-call", "allow-sign-payload", "allow-app-request"]

--- a/crates/tauri-plugin-holochain/src/commands.rs
+++ b/crates/tauri-plugin-holochain/src/commands.rs
@@ -1,4 +1,6 @@
-use crate::{HolochainExt, Result};
+use crate::{Error, HolochainExt, Result};
+use base64::prelude::*;
+use holochain::prelude::AgentPubKey;
 use holochain_conductor_runtime_types_ffi::{CellIdFfi, ZomeCallParamsFfi};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Runtime, WebviewWindow};
@@ -63,6 +65,62 @@ pub(crate) async fn sign_zome_call<R: Runtime>(
     })
 }
 
+/// Request to sign an arbitrary payload with a specific agent key.
+///
+/// `agent_key` is the raw 39-byte `AgentPubKey` of an identity this runtime's
+/// keystore already holds the private half of, e.g.
+/// [`holochain_conductor_runtime::Runtime::device_agent_key`] or
+/// [`holochain_conductor_runtime::Runtime::hc_auth_agent_key`]. There is no
+/// default identity: the caller must resolve and supply the exact key it
+/// means to sign with, since those are distinct identities and a signature
+/// from the wrong one is still valid, just for the wrong key.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SignPayloadRequest {
+    agent_key: Vec<u8>,
+    payload: Vec<u8>,
+}
+
+/// Signed payload returned to the caller.
+///
+/// Unlike [`SignZomeCallResponse`] (raw bytes, meant for `@holochain/client`'s
+/// binary wire format), this signature is base64-encoded: the payload here is
+/// caller-defined and typically destined for a JSON body, where a string is
+/// what a caller can place directly into a field, not a byte array to encode
+/// itself.
+#[derive(Debug, Serialize)]
+pub(crate) struct SignPayloadResponse {
+    /// The raw 64-byte Ed25519 signature, base64-encoded (standard alphabet,
+    /// padded).
+    signature: String,
+}
+
+/// Sign an arbitrary payload with a specific agent key held by the
+/// conductor's keystore.
+///
+/// General-purpose counterpart to [`sign_zome_call`]: that signs one fixed,
+/// structured payload; this signs whatever bytes the caller supplies, for any
+/// protocol that needs proof of control over a Holochain agent key. See
+/// [`SignPayloadRequest`] for how the signing key is chosen.
+#[tauri::command]
+pub(crate) async fn sign_payload<R: Runtime>(
+    app: AppHandle<R>,
+    request: SignPayloadRequest,
+) -> Result<SignPayloadResponse> {
+    let agent_key = AgentPubKey::try_from_raw_39(request.agent_key)
+        .map_err(|e| Error::Serialization(format!("invalid agent key: {e}")))?;
+
+    let signature = app
+        .holochain()?
+        .runtime()
+        .sign_payload(agent_key, request.payload)
+        .await?;
+
+    Ok(SignPayloadResponse {
+        signature: BASE64_STANDARD.encode(signature),
+    })
+}
+
 /// Serve an App API request for the calling window directly from the in-process
 /// conductor — the Tauri-IPC replacement for the app websocket.
 ///
@@ -81,4 +139,112 @@ pub(crate) async fn app_request<R: Runtime>(
         .holochain()?
         .app_request_bytes(&label, request)
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tauri::test::{mock_builder, mock_context, noop_assets};
+    use tempfile::TempDir;
+
+    fn build_app(tmp: &TempDir) -> tauri::App<tauri::test::MockRuntime> {
+        mock_builder()
+            .plugin(crate::init(
+                crate::vec_to_locked(vec![]),
+                crate::HolochainPluginConfig::new(
+                    tmp.path().to_path_buf(),
+                    crate::NetworkConfig::default(),
+                ),
+            ))
+            .build(mock_context(noop_assets()))
+            .expect("failed to build mock tauri app")
+    }
+
+    /// Mirrors `tests/integration.rs`'s `wait_for_ready`: the plugin handle is
+    /// managed before the conductor boots, so readiness means the runtime is
+    /// populated, not just that the plugin is registered.
+    async fn wait_for_ready<R: tauri::Runtime>(app: &tauri::App<R>) {
+        let mut waited = Duration::ZERO;
+        let step = Duration::from_millis(200);
+        while app.holochain().and_then(|p| p.try_runtime()).is_err() {
+            assert!(
+                waited < Duration::from_secs(60),
+                "conductor did not become ready within 60s"
+            );
+            tokio::time::sleep(step).await;
+            waited += step;
+        }
+    }
+
+    /// End-to-end through the command boundary: raw agent-key bytes in, a
+    /// base64 signature out that a JSON body can carry verbatim, and that
+    /// signature must be a genuine Ed25519 signature over exactly the
+    /// requested payload and key.
+    #[test]
+    fn sign_payload_returns_a_base64_signature_the_key_owns() {
+        let tmp = TempDir::new().unwrap();
+        let app = build_app(&tmp);
+
+        tauri::async_runtime::block_on(async move {
+            wait_for_ready(&app).await;
+            let app_handle = app.handle().clone();
+            let agent_key = app_handle.holochain().unwrap().runtime().device_agent_key();
+            let payload = b"hello reconnect".to_vec();
+
+            let response = sign_payload(
+                app_handle,
+                SignPayloadRequest {
+                    agent_key: agent_key.get_raw_39().to_vec(),
+                    payload: payload.clone(),
+                },
+            )
+            .await
+            .expect("sign_payload command should succeed");
+
+            let sig_bytes = BASE64_STANDARD
+                .decode(&response.signature)
+                .expect("signature must be standard-alphabet, padded base64");
+            assert_eq!(sig_bytes.len(), 64, "Ed25519 signatures are 64 bytes");
+
+            let mut pub_key_32 = [0u8; 32];
+            pub_key_32.copy_from_slice(agent_key.get_raw_32());
+            let mut sig_64 = [0u8; 64];
+            sig_64.copy_from_slice(&sig_bytes);
+            assert!(
+                sodoken::sign::verify_detached(&sig_64, &payload, &pub_key_32),
+                "decoded signature must verify against the requested key and payload"
+            );
+        });
+    }
+
+    /// Untrusted bytes from the webview must fail cleanly, not panic the
+    /// command task. `AgentPubKey::from_raw_39` (used elsewhere in this
+    /// codebase at the FFI boundary) panics on a bad length; this command
+    /// uses the fallible `try_from_raw_39` instead precisely to avoid that
+    /// here, where the input comes straight off the wire.
+    #[test]
+    fn sign_payload_rejects_a_malformed_agent_key_instead_of_panicking() {
+        let tmp = TempDir::new().unwrap();
+        let app = build_app(&tmp);
+
+        tauri::async_runtime::block_on(async move {
+            wait_for_ready(&app).await;
+            let app_handle = app.handle().clone();
+
+            let result = sign_payload(
+                app_handle,
+                SignPayloadRequest {
+                    agent_key: vec![1, 2, 3],
+                    payload: b"payload".to_vec(),
+                },
+            )
+            .await;
+
+            assert!(
+                matches!(result, Err(Error::Serialization(_))),
+                "a malformed agent key must fail cleanly, not panic: {result:?}"
+            );
+        });
+    }
 }

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -511,6 +511,7 @@ fn plugin_builder<R: TauriRuntime>(
     Builder::new("holochain")
         .invoke_handler(tauri::generate_handler![
             commands::sign_zome_call,
+            commands::sign_payload,
             commands::app_request
         ])
         .setup(move |app, _api| {

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -19,6 +19,11 @@ pub use error::{Error, Result};
 // Re-export the native config type consumers build, and the runtime itself.
 pub use holochain::conductor::config::NetworkConfig;
 pub use holochain_conductor_runtime::Runtime;
+// The runtime's error type — and the conductor error it carries — so consumers
+// can match `Runtime` call results (e.g. `RuntimeError::Conductor(ce)` holding a
+// `ConductorError::AppAlreadyInstalled`) without depending on the runtime crate
+// directly.
+pub use holochain_conductor_runtime::{ConductorError, RuntimeError};
 // hc-auth: re-export the module and its config/status types so consumers can
 // build a `HcAuthConfig` and read `HcAuthStatus` without depending on the
 // runtime crate directly.


### PR DESCRIPTION
  - `install_app` returns the typed `ConductorError` instead of an opaque string, so callers can match   
  the real failure.
  - `Runtime::sign_payload` signs an arbitrary payload with a caller-chosen agent key, exposed as a Tauri
  command.                            
  - `RuntimeError::Lair` carries lair's own message, which it previously discarded.  