### PR TITLE
feat: typed install_app errors, payload signing, and lair error detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - BREAKING: `HolochainPlugin::try_runtime` reports a failed conductor boot as the new `Error::SetupFailed`, carrying the cause, instead of `Error::NotReady` forever. `holochain://setup-failed` still fires with the same payload.
 - `Runtime::sign_payload` signs an arbitrary payload with a caller-chosen agent key via the keystore, for protocols beyond zome calls that need proof of control over an identity. Exposed through the in-process plugin as the `sign_payload` command, returning a base64-encoded signature. It is outside `holochain:default`, so a capability has to grant `holochain:allow-sign-payload` itself.
-- `RuntimeError::Lair` renders the underlying lair error instead of the bare string "Lair Error".
 - `Runtime::install_app` preserves the typed `ConductorError` (as `RuntimeError::Conductor`) instead of flattening it to a string.
 - Bump to holochain 0.7.0. New conductor types are carried across the FFI: `AppStatusFfi` gains `AwaitingRestore` and `Unrecoverable` (cell id + rendered reason); `InstallAppPayload.restore_from_dht` and `RoleSettings::Provisioned.init_properties` are not exposed over FFI yet (always `false`/`None`).
 - BREAKING: `RuntimeNetworkConfig` / `RuntimeNetworkConfigFfi` lose `signal_url` and `ice_urls` — holochain 0.7 dropped the tx5/WebRTC transport in favor of iroh, so the conductor `NetworkConfig` no longer carries them. Only `bootstrap_url` and `relay_url` remain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- `Runtime::install_app` preserves the typed `ConductorError` (as `RuntimeError::Conductor`) instead of flattening it to a string.
 - Bump to holochain 0.7.0. New conductor types are carried across the FFI: `AppStatusFfi` gains `AwaitingRestore` and `Unrecoverable` (cell id + rendered reason); `InstallAppPayload.restore_from_dht` and `RoleSettings::Provisioned.init_properties` are not exposed over FFI yet (always `false`/`None`).
 - BREAKING: `RuntimeNetworkConfig` / `RuntimeNetworkConfigFfi` lose `signal_url` and `ice_urls` — holochain 0.7 dropped the tx5/WebRTC transport in favor of iroh, so the conductor `NetworkConfig` no longer carries them. Only `bootstrap_url` and `relay_url` remain.
 - The forum test fixture is repacked with hdk 0.7.0 / hdi 0.8.0 (the 0.7 `Action`/`ActionData` restructure required porting the coordinator zome's signal emission).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - BREAKING: `HolochainPlugin::try_runtime` reports a failed conductor boot as the new `Error::SetupFailed`, carrying the cause, instead of `Error::NotReady` forever. `holochain://setup-failed` still fires with the same payload.
 - `Runtime::sign_payload` signs an arbitrary payload with a caller-chosen agent key via the keystore, for protocols beyond zome calls that need proof of control over an identity. Exposed through the in-process plugin as the `sign_payload` command, returning a base64-encoded signature. It is outside `holochain:default`, so a capability has to grant `holochain:allow-sign-payload` itself.
+- `RuntimeError::Lair` renders the underlying lair error instead of the bare string "Lair Error".
 - `Runtime::install_app` preserves the typed `ConductorError` (as `RuntimeError::Conductor`) instead of flattening it to a string.
 - Bump to holochain 0.7.0. New conductor types are carried across the FFI: `AppStatusFfi` gains `AwaitingRestore` and `Unrecoverable` (cell id + rendered reason); `InstallAppPayload.restore_from_dht` and `RoleSettings::Provisioned.init_properties` are not exposed over FFI yet (always `false`/`None`).
 - BREAKING: `RuntimeNetworkConfig` / `RuntimeNetworkConfigFfi` lose `signal_url` and `ice_urls` — holochain 0.7 dropped the tx5/WebRTC transport in favor of iroh, so the conductor `NetworkConfig` no longer carries them. Only `bootstrap_url` and `relay_url` remain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- `Runtime::sign_payload` signs an arbitrary payload with a caller-chosen agent key via the keystore, for protocols beyond zome calls that need proof of control over an identity. Exposed through the in-process plugin as the `sign_payload` command, returning a base64-encoded signature. It is outside `holochain:default`, so a capability has to grant `holochain:allow-sign-payload` itself.
 - `Runtime::install_app` preserves the typed `ConductorError` (as `RuntimeError::Conductor`) instead of flattening it to a string.
 - Bump to holochain 0.7.0. New conductor types are carried across the FFI: `AppStatusFfi` gains `AwaitingRestore` and `Unrecoverable` (cell id + rendered reason); `InstallAppPayload.restore_from_dht` and `RoleSettings::Provisioned.init_properties` are not exposed over FFI yet (always `false`/`None`).
 - BREAKING: `RuntimeNetworkConfig` / `RuntimeNetworkConfigFfi` lose `signal_url` and `ice_urls` — holochain 0.7 dropped the tx5/WebRTC transport in favor of iroh, so the conductor `NetworkConfig` no longer carries them. Only `bootstrap_url` and `relay_url` remain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- BREAKING: `HolochainPlugin::try_runtime` reports a failed conductor boot as the new `Error::SetupFailed`, carrying the cause, instead of `Error::NotReady` forever. `holochain://setup-failed` still fires with the same payload.
 - `Runtime::sign_payload` signs an arbitrary payload with a caller-chosen agent key via the keystore, for protocols beyond zome calls that need proof of control over an identity. Exposed through the in-process plugin as the `sign_payload` command, returning a base64-encoded signature. It is outside `holochain:default`, so a capability has to grant `holochain:allow-sign-payload` itself.
 - `Runtime::install_app` preserves the typed `ConductorError` (as `RuntimeError::Conductor`) instead of flattening it to a string.
 - Bump to holochain 0.7.0. New conductor types are carried across the FFI: `AppStatusFfi` gains `AwaitingRestore` and `Unrecoverable` (cell id + rendered reason); `InstallAppPayload.restore_from_dht` and `RoleSettings::Provisioned.init_properties` are not exposed over FFI yet (always `false`/`None`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9253,6 +9253,7 @@ dependencies = [
 name = "tauri-plugin-holochain"
 version = "0.2.2"
 dependencies = [
+ "base64 0.22.1",
  "holochain",
  "holochain-conductor-runtime",
  "holochain-conductor-runtime-types-ffi",
@@ -9263,6 +9264,7 @@ dependencies = [
  "sodoken",
  "tauri",
  "tauri-plugin",
+ "tauri-plugin-holochain",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tauri-build = { version = "2.2.0", default-features = false }
 # See https://github.com/holochain/android-service-runtime/issues/113
 uniffi = { package = "hc_uniffi", version = "=0.29.2" }
 
+base64 = "0.22"
 log = "0.4.25"
 android_logger = "0.14.1"
 serde = "1.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -18,7 +18,7 @@ lair_keystore_api = { workspace = true }
 # hc-auth: HTTP challenge/authenticate against the auth server + base64 material.
 # rustls-tls to match the workspace's rustls/aws-lc crypto stack (no native-tls).
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
-base64 = "0.22"
+base64 = { workspace = true }
 sodoken = { workspace = true }
 url2 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/runtime/src/error.rs
+++ b/crates/runtime/src/error.rs
@@ -31,7 +31,7 @@ pub enum RuntimeError {
     #[error("Failed to sign zome call {0}")]
     ZomeCallParamsInvalid(String),
 
-    #[error("Lair Error")]
+    #[error("Lair Error: {0}")]
     Lair(OneErr),
 
     #[error("hc-auth error: {0}")]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -15,6 +15,7 @@ pub use hc_auth::{HcAuthConfig, HcAuthStatus};
 
 mod error;
 pub use error::*;
+pub use holochain::conductor::error::ConductorError;
 
 mod config;
 pub use config::*;

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -329,13 +329,15 @@ impl Runtime {
     }
 
     pub async fn install_app(&self, payload: InstallAppPayload) -> RuntimeResult<AppInfo> {
-        let response = self
-            .req_admin_api(AdminRequest::InstallApp(Box::new(payload)))
-            .await?;
-        match response {
-            AdminResponse::AppInstalled(app_info) => Ok(app_info),
-            fail => Err(RuntimeError::AdminApiBadResponse(Box::new(fail))),
-        }
+        // Direct rather than through `AdminInterfaceApi::handle_request`, which
+        // flattens `ConductorError` into a print-only
+        // `ExternalApiWireError::InternalError(String)` (holochain TODO B-01506).
+        // Going direct also skips its `check_running` guard and its `AppInfo`
+        // assembly, so both happen here.
+        self.conductor.check_running()?;
+        let app = self.conductor.clone().install_app_bundle(payload).await?;
+        let dna_definitions = self.conductor.get_dna_definitions(&app).await?;
+        Ok(AppInfo::from_installed_app(&app, &dna_definitions))
     }
 
     pub async fn uninstall_app(&self, installed_app_id: String) -> RuntimeResult<()> {
@@ -851,7 +853,7 @@ impl Runtime {
 
 #[cfg(test)]
 mod test {
-    use crate::RuntimeNetworkConfig;
+    use crate::{ConductorError, RuntimeNetworkConfig};
 
     use super::*;
     use holochain::conductor::api::CellInfo::Provisioned;
@@ -1007,6 +1009,39 @@ mod test {
 
         let apps = runtime.list_apps().await.unwrap();
         assert_eq!(apps.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_install_app_already_installed() {
+        let tmp = TempDir::new().unwrap();
+        let runtime = boot_runtime(&tmp, None).await;
+
+        let original = install_happ_fixture(runtime.clone(), "my-app-1").await;
+
+        let err = runtime
+            .install_app(InstallAppPayload {
+                source: AppBundleSource::Bytes(HAPP_FIXTURE.to_vec().into()),
+                agent_key: None,
+                installed_app_id: Some("my-app-1".into()),
+                network_seed: Some(Uuid::new_v4().to_string()),
+                roles_settings: Some(HashMap::new()),
+                ignore_genesis_failure: false,
+                restore_from_dht: false,
+            })
+            .await
+            .expect_err("re-installing an existing app id must fail");
+
+        assert!(
+            matches!(&err, RuntimeError::Conductor(ce)
+                if matches!(&**ce, ConductorError::AppAlreadyInstalled(id) if id == "my-app-1")),
+            "expected RuntimeError::Conductor(ConductorError::AppAlreadyInstalled(\"my-app-1\")), got: {err:?}"
+        );
+
+        let apps = runtime.list_apps().await.unwrap();
+        assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0].installed_app_id, original.installed_app_id);
+        assert_eq!(apps[0].agent_pub_key, original.agent_pub_key);
+        assert_eq!(apps[0].cell_info, original.cell_info);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -657,6 +657,26 @@ impl Runtime {
         })
     }
 
+    /// There is no default identity: one keystore can hold several signable keys,
+    /// and signing with the wrong one still yields a *valid* signature, just for
+    /// the wrong identity, so the caller must pass the exact key it means.
+    pub async fn sign_payload(
+        &self,
+        agent_key: AgentPubKey,
+        payload: Vec<u8>,
+    ) -> RuntimeResult<[u8; 64]> {
+        let mut pub_key_32 = [0u8; 32];
+        pub_key_32.copy_from_slice(agent_key.get_raw_32());
+        let signature = self
+            .conductor
+            .keystore()
+            .lair_client()
+            .sign_by_pub_key(pub_key_32.into(), None, Arc::from(payload.as_slice()))
+            .await
+            .map_err(RuntimeError::Lair)?;
+        Ok(*signature.0)
+    }
+
     pub async fn ensure_app_websocket(
         &self,
         installed_app_id: InstalledAppId,
@@ -1391,6 +1411,96 @@ mod test {
             })
             .await;
         assert!(res.is_ok())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sign_payload_returns_a_verifiable_signature() {
+        let tmp = TempDir::new().unwrap();
+        let runtime = boot_runtime(&tmp, None).await;
+
+        let agent_key = runtime.device_agent_key();
+        let payload = b"arbitrary payload bytes, not a zome call".to_vec();
+
+        let signature = runtime
+            .sign_payload(agent_key.clone(), payload.clone())
+            .await
+            .expect("signing with a key this keystore holds must succeed");
+
+        let pub_key_32: [u8; 32] = agent_key.get_raw_32().try_into().unwrap();
+        assert!(
+            sodoken::sign::verify_detached(&signature, &payload, &pub_key_32),
+            "returned signature must verify against the signing key and payload"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sign_payload_binds_the_signature_to_the_requested_key_not_a_default() {
+        let tmp = TempDir::new().unwrap();
+        let runtime = boot_runtime(&tmp, None).await;
+
+        let device_key = runtime.device_agent_key();
+        let other_key = runtime.import_key_seed([5u8; 32]).await.unwrap();
+        assert_ne!(device_key, other_key);
+
+        let payload = b"same payload, two identities".to_vec();
+        let sig_device = runtime
+            .sign_payload(device_key.clone(), payload.clone())
+            .await
+            .unwrap();
+        let sig_other = runtime
+            .sign_payload(other_key.clone(), payload.clone())
+            .await
+            .unwrap();
+
+        assert_ne!(
+            sig_device, sig_other,
+            "different keys signing the same payload must produce different signatures"
+        );
+
+        let device_pk: [u8; 32] = device_key.get_raw_32().try_into().unwrap();
+        let other_pk: [u8; 32] = other_key.get_raw_32().try_into().unwrap();
+
+        assert!(sodoken::sign::verify_detached(
+            &sig_device,
+            &payload,
+            &device_pk
+        ));
+        assert!(sodoken::sign::verify_detached(
+            &sig_other, &payload, &other_pk
+        ));
+        assert!(!sodoken::sign::verify_detached(
+            &sig_device,
+            &payload,
+            &other_pk
+        ));
+        assert!(!sodoken::sign::verify_detached(
+            &sig_other, &payload, &device_pk
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sign_payload_fails_when_the_key_is_not_in_this_keystore() {
+        let tmp1 = TempDir::new().unwrap();
+        let rt1 = boot_runtime(&tmp1, None).await;
+
+        let tmp2 = TempDir::new().unwrap();
+        let rt2 = boot_runtime(&tmp2, None).await;
+        let foreign_key = rt2.device_agent_key();
+        assert_ne!(foreign_key, rt1.device_agent_key());
+
+        let err = rt1
+            .sign_payload(foreign_key, b"payload".to_vec())
+            .await
+            .expect_err("signing with a key this keystore does not hold must fail");
+        assert!(
+            matches!(err, RuntimeError::Lair(_)),
+            "expected RuntimeError::Lair, got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.starts_with("Lair Error: ") && message.len() > "Lair Error: ".len(),
+            "expected the underlying lair error detail in the message, got: {message:?}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/tauri-plugin-holochain/Cargo.toml
+++ b/crates/tauri-plugin-holochain/Cargo.toml
@@ -21,6 +21,10 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }
+base64 = { workspace = true }
+
+[features]
+test-utils = ["tauri/test"]
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
@@ -32,3 +36,5 @@ holochain_types = { workspace = true }
 tokio = { workspace = true }
 tempfile = { workspace = true }
 uuid = { workspace = true }
+# Self-dependency: what turns `test-utils` on for this crate's own test targets.
+tauri-plugin-holochain = { path = ".", features = ["test-utils"] }

--- a/crates/tauri-plugin-holochain/build.rs
+++ b/crates/tauri-plugin-holochain/build.rs
@@ -1,4 +1,4 @@
-const COMMANDS: &[&str] = &["sign_zome_call", "app_request"];
+const COMMANDS: &[&str] = &["sign_zome_call", "sign_payload", "app_request"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/crates/tauri-plugin-holochain/src/commands.rs
+++ b/crates/tauri-plugin-holochain/src/commands.rs
@@ -55,7 +55,7 @@ pub(crate) async fn sign_zome_call<R: Runtime>(
 
     let signed = app
         .holochain()?
-        .runtime()
+        .try_runtime()?
         .sign_zome_call(params.into())
         .await?;
 

--- a/crates/tauri-plugin-holochain/src/commands.rs
+++ b/crates/tauri-plugin-holochain/src/commands.rs
@@ -1,4 +1,6 @@
-use crate::{HolochainExt, Result};
+use crate::{Error, HolochainExt, Result};
+use base64::prelude::*;
+use holochain::prelude::AgentPubKey;
 use holochain_conductor_runtime_types_ffi::{CellIdFfi, ZomeCallParamsFfi};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Runtime, WebviewWindow};
@@ -63,6 +65,44 @@ pub(crate) async fn sign_zome_call<R: Runtime>(
     })
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SignPayloadRequest {
+    agent_key: Vec<u8>,
+    payload: Vec<u8>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SignPayloadResponse {
+    signature: String,
+}
+
+/// Deliberately outside the plugin's `default` permission set: [`sign_zome_call`]
+/// signs the hash of a well-formed `ZomeCallParams`, so what it produces is only
+/// usable as the zome call it describes, while this signs bytes the caller chose,
+/// which carry no such domain separation. A capability must name
+/// `allow-sign-payload` itself.
+#[tauri::command]
+pub(crate) async fn sign_payload<R: Runtime>(
+    app: AppHandle<R>,
+    request: SignPayloadRequest,
+) -> Result<SignPayloadResponse> {
+    // `from_raw_39`, used elsewhere at the FFI boundary, panics on a bad length or a
+    // mismatched hash prefix, and this input comes straight off the wire.
+    let agent_key = AgentPubKey::try_from_raw_39(request.agent_key)
+        .map_err(|e| Error::Serialization(format!("invalid agent key: {e}")))?;
+
+    let signature = app
+        .holochain()?
+        .try_runtime()?
+        .sign_payload(agent_key, request.payload)
+        .await?;
+
+    Ok(SignPayloadResponse {
+        signature: BASE64_STANDARD.encode(signature),
+    })
+}
+
 /// Serve an App API request for the calling window directly from the in-process
 /// conductor — the Tauri-IPC replacement for the app websocket.
 ///
@@ -81,4 +121,97 @@ pub(crate) async fn app_request<R: Runtime>(
         .holochain()?
         .app_request_bytes(&label, request)
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{build_app, plugin_config, wait_for_ready};
+    use tauri::test::{mock_builder, mock_context, noop_assets};
+    use tempfile::TempDir;
+
+    #[test]
+    fn sign_payload_returns_a_base64_signature_the_key_owns() {
+        let tmp = TempDir::new().unwrap();
+        let app = build_app(tmp.path());
+
+        tauri::async_runtime::block_on(async move {
+            wait_for_ready(&app).await;
+            let app_handle = app.handle().clone();
+            let agent_key = app_handle.holochain().unwrap().runtime().device_agent_key();
+            let payload = b"hello reconnect".to_vec();
+
+            let response = sign_payload(
+                app_handle,
+                SignPayloadRequest {
+                    agent_key: agent_key.get_raw_39().to_vec(),
+                    payload: payload.clone(),
+                },
+            )
+            .await
+            .expect("sign_payload command should succeed");
+
+            let sig_bytes = BASE64_STANDARD
+                .decode(&response.signature)
+                .expect("signature must be standard-alphabet, padded base64");
+            let sig_64: [u8; 64] = sig_bytes
+                .as_slice()
+                .try_into()
+                .expect("Ed25519 signatures are 64 bytes");
+            let pub_key_32: [u8; 32] = agent_key.get_raw_32().try_into().unwrap();
+            assert!(
+                sodoken::sign::verify_detached(&sig_64, &payload, &pub_key_32),
+                "decoded signature must verify against the requested key and payload"
+            );
+        });
+    }
+
+    #[test]
+    fn sign_payload_rejects_a_malformed_agent_key_instead_of_panicking() {
+        let tmp = TempDir::new().unwrap();
+        let app = build_app(tmp.path());
+
+        tauri::async_runtime::block_on(async move {
+            wait_for_ready(&app).await;
+            let app_handle = app.handle().clone();
+
+            let result = sign_payload(
+                app_handle,
+                SignPayloadRequest {
+                    agent_key: vec![1, 2, 3],
+                    payload: b"payload".to_vec(),
+                },
+            )
+            .await;
+
+            assert!(
+                matches!(result, Err(Error::Serialization(_))),
+                "a malformed agent key must fail cleanly, not panic: {result:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn sign_payload_reports_not_ready_before_the_conductor_starts() {
+        let tmp = TempDir::new().unwrap();
+        let app = mock_builder()
+            .plugin(crate::init_deferred(plugin_config(tmp.path())))
+            .build(mock_context(noop_assets()))
+            .expect("failed to build mock tauri app");
+
+        let result = tauri::async_runtime::block_on(sign_payload(
+            app.handle().clone(),
+            SignPayloadRequest {
+                agent_key: AgentPubKey::from_raw_32(vec![0u8; 32])
+                    .get_raw_39()
+                    .to_vec(),
+                payload: b"payload".to_vec(),
+            },
+        ));
+
+        assert!(
+            matches!(result, Err(Error::NotReady)),
+            "invoking before the conductor boots must return NotReady: {result:?}"
+        );
+    }
 }

--- a/crates/tauri-plugin-holochain/src/error.rs
+++ b/crates/tauri-plugin-holochain/src/error.rs
@@ -4,10 +4,16 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// The conductor has not finished starting yet. Wait for the
-    /// `holochain://ready` event before calling `holochain()`.
+    /// No conductor boot has finished: none was started, or one is in flight.
+    /// Also returned by [`crate::HolochainExt::holochain`] when the plugin is
+    /// not registered at all.
     #[error("the holochain conductor is not ready yet")]
     NotReady,
+
+    /// The conductor was started and failed to come up, carrying the same cause
+    /// `holochain://setup-failed` reports.
+    #[error("the holochain conductor failed to start: {0}")]
+    SetupFailed(String),
 
     /// [`crate::HolochainPlugin::start`] was called while the conductor is
     /// already running.

--- a/crates/tauri-plugin-holochain/src/error.rs
+++ b/crates/tauri-plugin-holochain/src/error.rs
@@ -31,7 +31,8 @@ pub enum Error {
     #[error("no holochain app is bound to this window")]
     WindowNotBound,
 
-    /// Failed to (de)serialize an App API request or response.
+    /// A value crossing the IPC boundary could not be decoded: an App API
+    /// request or response, or a command argument such as an agent key.
     #[error("serialization error: {0}")]
     Serialization(String),
 }

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -19,6 +19,7 @@ pub use error::{Error, Result};
 // Re-export the native config type consumers build, and the runtime itself.
 pub use holochain::conductor::config::NetworkConfig;
 pub use holochain_conductor_runtime::Runtime;
+pub use holochain_conductor_runtime::{ConductorError, RuntimeError};
 // hc-auth: re-export the module and its config/status types so consumers can
 // build a `HcAuthConfig` and read `HcAuthStatus` without depending on the
 // runtime crate directly.

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -136,17 +136,30 @@ pub struct WindowOptions {
     pub use_app_websocket: bool,
 }
 
+/// Outcome of the conductor boot, held in place of a bare `Option<Runtime>` so a
+/// failure is remembered rather than looking the same as a boot still in flight.
+enum BootState {
+    /// No boot has finished: either none was started ([`init_deferred`]) or one
+    /// is still running.
+    NotStarted,
+    Ready(Runtime),
+    /// The last boot attempt failed with this cause. Kept even though
+    /// [`EVENT_SETUP_FAILED`] carries the same string: that event is transient,
+    /// so anything not already listening when it fires cannot recover the cause.
+    Failed(String),
+}
+
 /// Access to the running in-process Holochain conductor from the Tauri app.
 ///
 /// The plugin may be registered before the conductor boots ([`init_deferred`]),
 /// so the runtime is populated late by [`HolochainPlugin::start`]. Until then
-/// [`HolochainPlugin::runtime`] panics and the internal accessors return
-/// [`Error::NotReady`].
+/// [`HolochainPlugin::runtime`] panics and [`HolochainPlugin::try_runtime`]
+/// reports [`Error::NotReady`], or [`Error::SetupFailed`] once a boot has failed.
 pub struct HolochainPlugin<R: TauriRuntime> {
-    /// The conductor runtime, populated once [`HolochainPlugin::start`] succeeds.
-    /// Behind an `RwLock` so a hot restart can swap in a new runtime on the same
-    /// lair without re-registering the plugin (see `swap_runtime`).
-    runtime: RwLock<Option<Runtime>>,
+    /// What the conductor boot has produced so far. Behind an `RwLock` so a hot
+    /// restart can swap in a new runtime on the same lair without re-registering
+    /// the plugin (see `swap_runtime`).
+    boot_state: RwLock<BootState>,
     /// Boot config, consumed by [`HolochainPlugin::start`]. Kept (not taken) so a
     /// failed unlock can be retried with a different passphrase.
     pending_config: Mutex<Option<HolochainPluginConfig>>,
@@ -184,10 +197,15 @@ impl<R: TauriRuntime> HolochainPlugin<R> {
         )
     }
 
-    /// Like [`HolochainPlugin::runtime`] but returns [`Error::NotReady`] instead
-    /// of panicking when the conductor has not started.
+    /// Like [`HolochainPlugin::runtime`] but returns an error instead of
+    /// panicking: [`Error::NotReady`] while no boot has completed, or
+    /// [`Error::SetupFailed`] carrying the cause once one has failed.
     pub fn try_runtime(&self) -> Result<Runtime> {
-        self.runtime.read().unwrap().clone().ok_or(Error::NotReady)
+        match &*self.boot_state.read().unwrap() {
+            BootState::Ready(runtime) => Ok(runtime.clone()),
+            BootState::Failed(cause) => Err(Error::SetupFailed(cause.clone())),
+            BootState::NotStarted => Err(Error::NotReady),
+        }
     }
 
     /// Boot the conductor with `passphrase` using the config supplied at
@@ -215,9 +233,11 @@ impl<R: TauriRuntime> HolochainPlugin<R> {
     /// [`EVENT_LAIR_READY`] once the keystore is available and [`EVENT_READY`]
     /// once the conductor is up.
     ///
-    /// Retryable: a failed unlock leaves the plugin un-started so a subsequent
-    /// call with a corrected passphrase/config can succeed. Returns
-    /// [`Error::AlreadyStarted`] if the conductor is already running.
+    /// Retryable: a failed boot records its cause (reported by
+    /// [`HolochainPlugin::try_runtime`] as [`Error::SetupFailed`]) and leaves the
+    /// conductor unstarted, so a subsequent call with a corrected
+    /// passphrase/config can succeed. Returns [`Error::AlreadyStarted`] if the
+    /// conductor is already running.
     pub async fn start_with_config(
         &self,
         passphrase: SharedLockedArray,
@@ -225,10 +245,33 @@ impl<R: TauriRuntime> HolochainPlugin<R> {
     ) -> Result<()> {
         // Serialize concurrent unlock attempts and re-check under the lock.
         let _guard = self.start_lock.lock().await;
-        if self.runtime.read().unwrap().is_some() {
-            return Err(Error::AlreadyStarted);
+        {
+            let mut state = self.boot_state.write().unwrap();
+            if matches!(*state, BootState::Ready(_)) {
+                return Err(Error::AlreadyStarted);
+            }
+            // This attempt supersedes the last one's cause: while it is in flight
+            // the plugin is not-started, not still-failed.
+            *state = BootState::NotStarted;
         }
 
+        let result = self.boot(passphrase, config).await;
+        if let Err(e) = &result {
+            let mut state = self.boot_state.write().unwrap();
+            // `swap_runtime` may have installed a live runtime while this attempt
+            // was in flight, and failing it must not drop that runtime.
+            if !matches!(*state, BootState::Ready(_)) {
+                *state = BootState::Failed(e.to_string());
+            }
+        }
+        result
+    }
+
+    async fn boot(
+        &self,
+        passphrase: SharedLockedArray,
+        config: HolochainPluginConfig,
+    ) -> Result<()> {
         // Spawn lair, (optionally) run the hc-auth flow, then bring the conductor
         // up against that lair — see `Runtime::new_with_boot_config`. The
         // controllable boot collapses to a single conductor start; the keystore
@@ -248,7 +291,7 @@ impl<R: TauriRuntime> HolochainPlugin<R> {
             log::error!("Failed to emit {EVENT_LAIR_READY}: {e:?}");
         }
 
-        *self.runtime.write().unwrap() = Some(runtime);
+        *self.boot_state.write().unwrap() = BootState::Ready(runtime);
 
         if let Err(e) = self.app_handle.emit(EVENT_READY, ()) {
             log::error!("Failed to emit {EVENT_READY}: {e:?}");
@@ -264,7 +307,7 @@ impl<R: TauriRuntime> HolochainPlugin<R> {
     /// runtime — signal subscriptions are per-runtime and the old conductor's
     /// channels are gone after the restart.
     pub async fn swap_runtime(&self, new: Runtime) -> Result<()> {
-        *self.runtime.write().unwrap() = Some(new);
+        *self.boot_state.write().unwrap() = BootState::Ready(new);
 
         let bindings: Vec<(String, InstalledAppId)> = self
             .window_apps
@@ -515,7 +558,7 @@ fn plugin_builder<R: TauriRuntime>(
         ])
         .setup(move |app, _api| {
             app.manage(HolochainPlugin {
-                runtime: RwLock::new(None),
+                boot_state: RwLock::new(BootState::NotStarted),
                 pending_config: Mutex::new(Some(config.clone())),
                 start_lock: tokio::sync::Mutex::new(()),
                 app_handle: app.clone(),

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -14,6 +14,9 @@
 mod commands;
 mod error;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_support;
+
 pub use error::{Error, Result};
 
 // Re-export the native config type consumers build, and the runtime itself.
@@ -507,6 +510,7 @@ fn plugin_builder<R: TauriRuntime>(
     Builder::new("holochain")
         .invoke_handler(tauri::generate_handler![
             commands::sign_zome_call,
+            commands::sign_payload,
             commands::app_request
         ])
         .setup(move |app, _api| {

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -257,11 +257,23 @@ impl<R: TauriRuntime> HolochainPlugin<R> {
 
         let result = self.boot(passphrase, config).await;
         if let Err(e) = &result {
-            let mut state = self.boot_state.write().unwrap();
-            // `swap_runtime` may have installed a live runtime while this attempt
-            // was in flight, and failing it must not drop that runtime.
-            if !matches!(*state, BootState::Ready(_)) {
-                *state = BootState::Failed(e.to_string());
+            let cause = e.to_string();
+            let recorded = {
+                let mut state = self.boot_state.write().unwrap();
+                // `swap_runtime` may have installed a live runtime while this attempt
+                // was in flight, and failing it must not drop that runtime.
+                if matches!(*state, BootState::Ready(_)) {
+                    false
+                } else {
+                    *state = BootState::Failed(cause.clone());
+                    true
+                }
+            };
+            // Emitted here rather than at the call site so a deferred `start` reports
+            // the failure too, and outside the lock so a listener may call back in.
+            if recorded {
+                log::error!("Holochain conductor setup failed: {e:?}");
+                let _ = self.app_handle.emit(EVENT_SETUP_FAILED, cause);
             }
         }
         result
@@ -604,13 +616,15 @@ pub fn init<R: TauriRuntime>(
         tauri::async_runtime::spawn(async move {
             // `holochain()` borrows manager-lifetime state, so the reference is
             // valid across the await (app_handle outlives the task).
-            let result = match app_handle.holochain() {
-                Ok(plugin) => plugin.start(passphrase).await,
-                Err(e) => Err(e),
-            };
-            if let Err(e) = result {
-                log::error!("Holochain conductor setup failed: {e:?}");
-                let _ = app_handle.emit(EVENT_SETUP_FAILED, e.to_string());
+            match app_handle.holochain() {
+                // `start` reports its own failure, event included.
+                Ok(plugin) => {
+                    let _ = plugin.start(passphrase).await;
+                }
+                Err(e) => {
+                    log::error!("Holochain conductor setup failed: {e:?}");
+                    let _ = app_handle.emit(EVENT_SETUP_FAILED, e.to_string());
+                }
             }
         });
     })

--- a/crates/tauri-plugin-holochain/src/test_support.rs
+++ b/crates/tauri-plugin-holochain/src/test_support.rs
@@ -1,0 +1,40 @@
+//! Mock-app helpers for this crate's unit tests and `tests/integration.rs`, which
+//! links the crate externally and so cannot see `#[cfg(test)]` items in `src/`.
+
+use crate::{HolochainExt, HolochainPluginConfig, NetworkConfig};
+use std::path::Path;
+use std::time::Duration;
+use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
+use tauri::App;
+
+const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+pub fn plugin_config(data_dir: &Path) -> HolochainPluginConfig {
+    HolochainPluginConfig::new(data_dir.to_path_buf(), NetworkConfig::default())
+}
+
+pub fn build_app(data_dir: &Path) -> App<MockRuntime> {
+    mock_builder()
+        .plugin(crate::init(
+            crate::vec_to_locked(vec![]),
+            plugin_config(data_dir),
+        ))
+        .build(mock_context(noop_assets()))
+        .expect("failed to build mock tauri app")
+}
+
+/// Gating on `holochain()` alone is not enough: the plugin handle is managed
+/// before the conductor boots, so `init_deferred` consumers can call `start`.
+/// The readiness signal is the runtime, not the handle.
+pub async fn wait_for_ready<R: tauri::Runtime>(app: &App<R>) {
+    let ready = async {
+        while app.holochain().and_then(|p| p.try_runtime()).is_err() {
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    };
+
+    tokio::time::timeout(BOOT_TIMEOUT, ready)
+        .await
+        .unwrap_or_else(|_| panic!("conductor did not become ready within {BOOT_TIMEOUT:?}"));
+}

--- a/crates/tauri-plugin-holochain/src/test_support.rs
+++ b/crates/tauri-plugin-holochain/src/test_support.rs
@@ -1,13 +1,13 @@
 //! Mock-app helpers for this crate's unit tests and `tests/integration.rs`, which
 //! links the crate externally and so cannot see `#[cfg(test)]` items in `src/`.
 
-use crate::{HolochainExt, HolochainPluginConfig, NetworkConfig};
+use crate::{Error, HolochainExt, HolochainPluginConfig, NetworkConfig};
 use std::path::Path;
 use std::time::Duration;
 use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
 use tauri::App;
 
-const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
+pub const BOOT_TIMEOUT: Duration = Duration::from_secs(60);
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 pub fn plugin_config(data_dir: &Path) -> HolochainPluginConfig {
@@ -27,10 +27,17 @@ pub fn build_app(data_dir: &Path) -> App<MockRuntime> {
 /// Gating on `holochain()` alone is not enough: the plugin handle is managed
 /// before the conductor boots, so `init_deferred` consumers can call `start`.
 /// The readiness signal is the runtime, not the handle.
+///
+/// Panics with the boot error as soon as one is reported, so a failed boot fails
+/// the test on its actual cause instead of on the timeout.
 pub async fn wait_for_ready<R: tauri::Runtime>(app: &App<R>) {
     let ready = async {
-        while app.holochain().and_then(|p| p.try_runtime()).is_err() {
-            tokio::time::sleep(POLL_INTERVAL).await;
+        loop {
+            match app.holochain().and_then(|p| p.try_runtime()) {
+                Ok(_) => return,
+                Err(Error::SetupFailed(cause)) => panic!("conductor setup failed: {cause}"),
+                Err(_) => tokio::time::sleep(POLL_INTERVAL).await,
+            }
         }
     };
 

--- a/crates/tauri-plugin-holochain/tests/integration.rs
+++ b/crates/tauri-plugin-holochain/tests/integration.rs
@@ -8,6 +8,8 @@
 //! app (Approach B).
 
 use std::collections::HashMap;
+use std::panic::AssertUnwindSafe;
+use std::time::Instant;
 
 use holochain::conductor::api::CellInfo::Provisioned;
 use holochain::conductor::api::{AppRequest, AppResponse, ProvisionedCell};
@@ -16,7 +18,7 @@ use holochain::prelude::{
 };
 use holochain_types::prelude::{AppStatus, Link, Nonce256Bits, Timestamp};
 use tauri::test::{mock_builder, mock_context, noop_assets};
-use tauri_plugin_holochain::test_support::{build_app, wait_for_ready};
+use tauri_plugin_holochain::test_support::{build_app, wait_for_ready, BOOT_TIMEOUT};
 use tauri_plugin_holochain::{Error, HolochainExt, HolochainPluginConfig, NetworkConfig};
 use tempfile::TempDir;
 use uuid::Uuid;
@@ -296,5 +298,40 @@ fn shipped_bundle_matches_rebound_payload_shape() {
     assert!(
         bundle.contains("payload.app_id") && bundle.contains("payload.seq"),
         "dist-js/holochain-env/index.min.js is stale — run `npm run build` in crates/tauri-plugin-holochain"
+    );
+}
+
+/// A conductor that fails to boot has to say why: the plugin holds the setup
+/// error, so a waiter fails on the cause at once instead of sitting out
+/// `BOOT_TIMEOUT` and reporting only that nothing became ready.
+#[test]
+fn failed_boot_reports_its_cause_instead_of_timing_out() {
+    let tmp = TempDir::new().unwrap();
+    // A regular file cannot hold the conductor's data root, so lair fails to
+    // spawn and the boot errors within moments of the app being built.
+    let data_root = tmp.path().join("data-root");
+    std::fs::write(&data_root, b"").unwrap();
+    let app = build_app(&data_root);
+
+    let started = Instant::now();
+    let panic = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        tauri::async_runtime::block_on(wait_for_ready(&app));
+    }))
+    .expect_err("waiting on a conductor that cannot boot must fail the test");
+    let elapsed = started.elapsed();
+
+    let Err(Error::SetupFailed(cause)) = app.holochain().unwrap().try_runtime() else {
+        panic!("a failed boot must be reported as SetupFailed, not NotReady");
+    };
+    let message = panic
+        .downcast_ref::<String>()
+        .expect("the panic message is formatted, so it is a String");
+    assert!(
+        message.contains(&cause),
+        "the waiter must fail on the boot error, got: {message}"
+    );
+    assert!(
+        elapsed < BOOT_TIMEOUT / 2,
+        "the boot error must surface without waiting out {BOOT_TIMEOUT:?}, took {elapsed:?}"
     );
 }

--- a/crates/tauri-plugin-holochain/tests/integration.rs
+++ b/crates/tauri-plugin-holochain/tests/integration.rs
@@ -8,7 +8,6 @@
 //! app (Approach B).
 
 use std::collections::HashMap;
-use std::time::Duration;
 
 use holochain::conductor::api::CellInfo::Provisioned;
 use holochain::conductor::api::{AppRequest, AppResponse, ProvisionedCell};
@@ -17,43 +16,13 @@ use holochain::prelude::{
 };
 use holochain_types::prelude::{AppStatus, Link, Nonce256Bits, Timestamp};
 use tauri::test::{mock_builder, mock_context, noop_assets};
-use tauri_plugin_holochain::{
-    vec_to_locked, Error, HolochainExt, HolochainPluginConfig, NetworkConfig,
-};
+use tauri_plugin_holochain::test_support::{build_app, wait_for_ready};
+use tauri_plugin_holochain::{Error, HolochainExt, HolochainPluginConfig, NetworkConfig};
 use tempfile::TempDir;
 use uuid::Uuid;
 
 const HAPP_FIXTURE: &[u8] = include_bytes!("../../runtime/fixtures/forum.happ");
 const APP_ID: &str = "forum";
-
-/// Build a mock Tauri app with the plugin installed.
-fn build_app(tmp: &TempDir) -> tauri::App<tauri::test::MockRuntime> {
-    mock_builder()
-        .plugin(tauri_plugin_holochain::init(
-            vec_to_locked(vec![]),
-            HolochainPluginConfig::new(tmp.path().to_path_buf(), NetworkConfig::default()),
-        ))
-        .build(mock_context(noop_assets()))
-        .expect("failed to build mock tauri app")
-}
-
-/// Wait until the conductor has booted — i.e. the plugin's runtime is populated
-/// (it emits `holochain://ready` at that point). Gating on `holochain()` alone
-/// is not enough: the plugin handle is managed before the conductor boots (so
-/// `init_deferred` consumers can call `start`), so the readiness signal is the
-/// runtime, not the handle.
-async fn wait_for_ready<R: tauri::Runtime>(app: &tauri::App<R>) {
-    let mut waited = Duration::ZERO;
-    let step = Duration::from_millis(200);
-    while app.holochain().and_then(|p| p.try_runtime()).is_err() {
-        assert!(
-            waited < Duration::from_secs(60),
-            "conductor did not become ready within 60s"
-        );
-        tokio::time::sleep(step).await;
-        waited += step;
-    }
-}
 
 async fn install_and_enable_forum(
     runtime: &tauri_plugin_holochain::Runtime,
@@ -80,7 +49,7 @@ async fn install_and_enable_forum(
 #[test]
 fn plugin_boots_conductor_in_tauri_app() {
     let tmp = TempDir::new().unwrap();
-    let app = build_app(&tmp);
+    let app = build_app(tmp.path());
 
     // Everything runs on Tauri's async runtime (where the plugin spawned the
     // conductor boot), avoiding cross-runtime issues.
@@ -116,7 +85,7 @@ fn plugin_boots_conductor_in_tauri_app() {
 #[test]
 fn app_request_serves_app_api_in_process() {
     let tmp = TempDir::new().unwrap();
-    let app = build_app(&tmp);
+    let app = build_app(tmp.path());
 
     tauri::async_runtime::block_on(async move {
         wait_for_ready(&app).await;
@@ -188,7 +157,7 @@ fn app_request_serves_app_api_in_process() {
 #[test]
 fn rebind_window_reroutes_app_request_in_place() {
     let tmp = TempDir::new().unwrap();
-    let app = build_app(&tmp);
+    let app = build_app(tmp.path());
 
     tauri::async_runtime::block_on(async move {
         wait_for_ready(&app).await;


### PR DESCRIPTION
- `install_app` preserves the typed `ConductorError` instead of flattening every failure into a string, so a caller can tell an already-installed app from a real fault without matching on text.
- `RuntimeError::Lair` carries lair's own error detail, rather than reporting a category with no cause.
- A new command signs an arbitrary payload with a caller-chosen agent key, for callers that must prove control of a key outside a zome call.
