### PR TITLE
fix: Carry relay auth material into the per-space network config

### DIFF
--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -74,6 +74,82 @@ pub struct RuntimeBootConfig {
     pub pending_import_seed: Option<Vec<u8>>,
 }
 
+/// Also carry the relay auth material in `network.advanced`, where kitsune2 reads it
+/// per space.
+///
+/// `base64_auth_material_relay` only seeds the transport at startup. The config
+/// `NetworkConfig::to_k2_config` builds carries `irohTransport.relayUrl` but no material,
+/// and kitsune2 re-inserts the relay from it when a space is created — tokenless, which an
+/// authenticated relay refuses. The node keeps authenticating and keeps its allowlist entry
+/// alive, so the only symptom is that it reaches no peers.
+///
+/// `to_k2_config` merges into `advanced` rather than replacing it, so a value set here
+/// survives alongside the URL it writes.
+fn set_per_space_relay_material(network: &mut NetworkConfig, material: &str) {
+    let advanced = network
+        .advanced
+        .get_or_insert_with(|| serde_json::json!({}));
+    let Some(root) = advanced.as_object_mut() else {
+        log::warn!("network.advanced is not an object; relay auth material not set per space");
+        return;
+    };
+    let iroh = root
+        .entry("irohTransport")
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(iroh) = iroh.as_object_mut() else {
+        log::warn!(
+            "network.advanced.irohTransport is not an object; relay auth material not set per space"
+        );
+        return;
+    };
+    iroh.insert(
+        "authMaterialRelayBase64".to_string(),
+        serde_json::Value::String(material.to_string()),
+    );
+}
+
+#[cfg(test)]
+mod per_space_relay_material {
+    use super::*;
+
+    #[test]
+    fn lands_where_kitsune2_reads_it() {
+        let mut network = NetworkConfig::default();
+        set_per_space_relay_material(&mut network, "bWF0ZXJpYWw=");
+        assert_eq!(
+            network.advanced.expect("advanced set")["irohTransport"]["authMaterialRelayBase64"],
+            serde_json::json!("bWF0ZXJpYWw=")
+        );
+    }
+
+    /// `advanced` is caller-owned - a testnet build sets `relayAllowPlainText` here - so the
+    /// material has to be added to it rather than replace it.
+    #[test]
+    fn leaves_other_advanced_settings_alone() {
+        let mut network = NetworkConfig::default();
+        network.advanced = Some(serde_json::json!({
+            "irohTransport": { "relayAllowPlainText": true },
+            "coreBootstrap": { "serverUrl": "https://bootstrap.example" },
+        }));
+
+        set_per_space_relay_material(&mut network, "bWF0ZXJpYWw=");
+
+        let advanced = network.advanced.expect("advanced set");
+        assert_eq!(
+            advanced["irohTransport"]["relayAllowPlainText"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            advanced["coreBootstrap"]["serverUrl"],
+            serde_json::json!("https://bootstrap.example")
+        );
+        assert_eq!(
+            advanced["irohTransport"]["authMaterialRelayBase64"],
+            serde_json::json!("bWF0ZXJpYWw=")
+        );
+    }
+}
+
 impl Runtime {
     /// Initialize and start a new Conductor from a [`RuntimeConfig`].
     ///
@@ -196,6 +272,7 @@ impl Runtime {
                         }
                         if cfg.auth_relay {
                             network.base64_auth_material_relay = Some(material.clone());
+                            set_per_space_relay_material(&mut network, material);
                         }
                         log::info!(
                             "hc-auth: material injected (bootstrap={}, relay={})",
@@ -597,6 +674,7 @@ impl Runtime {
             }
             if add_auth_material_to_relay {
                 network.base64_auth_material_relay = Some(material.clone());
+                set_per_space_relay_material(&mut network, material);
             }
         }
 


### PR DESCRIPTION
A conductor using an authenticated relay loses relay access the moment its first
cell is created, and nothing in the auth path reports a problem.

## Symptom

```
Authenticating for relay access server_url=https://…/
Keeping iroh endpoint key registered … iroh_key=M6ZTsg…
Iroh relay keepalive succeeded
Relay authentication complete, proceeding to insert relay
…::app_status_impls: Creating a cell cell_id=CellId(DnaHash(…), …)
do_insert_relay: relay added, local URL constructed
iroh::socket::transports::relay::actor: Failed to connect to relay server:
    unable to connect: The relay denied our authentication (not authorized)
```

The HTTP auth never fails. The keepalive keeps succeeding every two minutes for
as long as the process runs, so the node holds a valid token and a live allowlist
entry while being refused at the socket. The only symptom is that it reaches no
peers, with every service reporting healthy.

## Cause

`base64_auth_material_relay` seeds the transport at startup only. The config
`NetworkConfig::to_k2_config` builds carries `irohTransport.relayUrl` but no
material, and `IrohTransport::configure_for_space` re-inserts the relay from that
config when a space is created:

```rust
let relay_url = per_space.as_ref().and_then(|c| c.relay_url.clone());
let auth_material = per_space.as_ref()
    .and_then(|c| c.auth_material_relay_base64.as_ref())   // never set
    …
if let Some(url) = relay_url { … do_insert_relay(endpoint, url, auth_material) … }
```

`relay_url` is always present and `auth_material` never is, so the authenticated
relay is replaced by a tokenless one. `TokenAccess::on_connect` gates both of its
allow-paths on a token being present, so the recovery allowlist cannot admit it
either.

A node with a public address never notices — it connects directly and never
exercises the relay socket. It only bites peers behind NAT, which is why a fleet
of public nodes can look entirely healthy while every desktop client fails.

## Fix

Write the material into `network.advanced` as well, where kitsune2 reads it per
space. `to_k2_config` merges into `advanced` rather than replacing it, so the
value survives alongside the URL it writes — and a caller's own advanced settings
(a testnet build sets `relayAllowPlainText` there) survive too, which the second
test pins.

Both injection sites are covered: the boot path and `restart_with_hc_auth`.
Patching only the first works on a cold start and fails after an in-app restart.

## Verification

Two unit tests, plus an end-to-end check: a NAT'd desktop client that previously
never reached a peer now joins a production network behind an authenticated
`kitsune2_bootstrap_srv` and syncs. A public peer passes either way, so it is not
a useful test of this.

## Two things worth a second opinion

1. **This may belong upstream instead.** kitsune2 documents
   `auth_material_relay_base64` as "Ignored in the global config", which forces
   every consumer to duplicate the material per space. If that asymmetry is not
   deliberate, the better fix is for holochain's `to_k2_config` to carry it — or
   for kitsune2 to fall back to the global material when a per-space override
   supplies none. This change is correct regardless, but it is a workaround for
   an awkward contract.
2. **It puts a credential in the logs.** Holochain redacts
   `auth_material_relay` in its debug output but prints `network_config` in full,
   so the material now appears in clear text in the boot line. It is effectively a
   bearer credential for the relay. Worth pairing with redaction wherever this
   lands.